### PR TITLE
V0.2.0

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -6,10 +6,13 @@ WORKDIR /home/sdk
 
 RUN apt update && \
     apt install --no-install-recommends -y \
-        iproute2 htop btop nvtop nload \
+        iproute2 htop btop nvtop nload pciutils \
         && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install --no-cache-dir "jupyterlab>=4,<5" "notebook>=7,<8" "jupyter-server>=2,<3" "jupyterlab-nvdashboard"
+RUN python3 -m pip install --no-cache-dir "jupyterlab>=4,<5" \
+                                          "notebook>=7,<8" \
+                                          "jupyter-server>=2,<3" \
+                                          "jupyterlab-nvdashboard"
 
 EXPOSE 8888
 

--- a/include/stelline/operators/blade/base.hh
+++ b/include/stelline/operators/blade/base.hh
@@ -7,6 +7,7 @@
 
 #include <stelline/yaml/types/block_shape.hh>
 #include <stelline/yaml/types/map.hh>
+#include <stelline/store.hh>
 
 namespace stelline::operators::blade {
 
@@ -16,8 +17,7 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
-
-class STELLINE_API CorrelatorOp : public Operator {
+class STELLINE_API CorrelatorOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(CorrelatorOp)
 
@@ -29,6 +29,9 @@ class STELLINE_API CorrelatorOp : public Operator {
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
+
  private:
     struct Impl;
     Impl* pimpl;
@@ -39,7 +42,7 @@ class STELLINE_API CorrelatorOp : public Operator {
     Parameter<Map> options_;
 };
 
-class STELLINE_API FrbnnOp : public Operator {
+class STELLINE_API FrbnnOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(FrbnnOp)
 
@@ -51,6 +54,9 @@ class STELLINE_API FrbnnOp : public Operator {
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
+
  private:
     struct Impl;
     Impl* pimpl;
@@ -61,7 +67,7 @@ class STELLINE_API FrbnnOp : public Operator {
     Parameter<Map> options_;
 };
 
-class STELLINE_API BeamformerOp : public Operator {
+class STELLINE_API BeamformerOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(BeamformerOp)
 
@@ -72,6 +78,9 @@ class STELLINE_API BeamformerOp : public Operator {
     void start() override;
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
 
  private:
     struct Impl;

--- a/include/stelline/operators/filesystem/base.hh
+++ b/include/stelline/operators/filesystem/base.hh
@@ -4,6 +4,7 @@
 #include <holoscan/holoscan.hpp>
 
 #include <stelline/common.hh>
+#include <stelline/store.hh>
 
 
 namespace stelline::operators::filesystem {
@@ -14,8 +15,7 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
-
-class STELLINE_API SimpleWriterOp : public Operator {
+class STELLINE_API SimpleWriterOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(SimpleWriterOp)
 
@@ -27,6 +27,9 @@ class STELLINE_API SimpleWriterOp : public Operator {
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
+
  private:
     struct Impl;
     Impl* pimpl;
@@ -34,7 +37,7 @@ class STELLINE_API SimpleWriterOp : public Operator {
     Parameter<std::string> filePath_;
 };
 
-class STELLINE_API SimpleWriterRdmaOp : public Operator {
+class STELLINE_API SimpleWriterRdmaOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(SimpleWriterRdmaOp)
 
@@ -46,6 +49,9 @@ class STELLINE_API SimpleWriterRdmaOp : public Operator {
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
+
  private:
     struct Impl;
     Impl* pimpl;
@@ -53,7 +59,7 @@ class STELLINE_API SimpleWriterRdmaOp : public Operator {
     Parameter<std::string> filePath_;
 };
 
-class STELLINE_API DummyWriterOp : public Operator {
+class STELLINE_API DummyWriterOp : public Operator, public stelline::StoreInterface {
  public:
       HOLOSCAN_OPERATOR_FORWARD_ARGS(DummyWriterOp)
 
@@ -66,13 +72,16 @@ class STELLINE_API DummyWriterOp : public Operator {
       void stop() override;
       void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+      StoreInterface::MetricsMap collectMetricsMap() override;
+      std::string collectMetricsString() override;
+
  private:
       struct Impl;
       Impl* pimpl;
 };
 
 #ifdef STELLINE_LOADER_FBH5
-class STELLINE_API Fbh5WriterRdmaOp : public Operator {
+class STELLINE_API Fbh5WriterRdmaOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(Fbh5WriterRdmaOp)
 
@@ -84,6 +93,9 @@ class STELLINE_API Fbh5WriterRdmaOp : public Operator {
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
 
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
+
  private:
     struct Impl;
     Impl* pimpl;
@@ -93,7 +105,7 @@ class STELLINE_API Fbh5WriterRdmaOp : public Operator {
 #endif  // STELLINE_LOADER_FBH5
 
 #ifdef STELLINE_LOADER_UVH5
-class STELLINE_API Uvh5WriterRdmaOp : public Operator {
+class STELLINE_API Uvh5WriterRdmaOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(Uvh5WriterRdmaOp)
 
@@ -104,6 +116,9 @@ class STELLINE_API Uvh5WriterRdmaOp : public Operator {
     void start() override;
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
 
  private:
     struct Impl;

--- a/include/stelline/operators/frbnn/base.hh
+++ b/include/stelline/operators/frbnn/base.hh
@@ -4,6 +4,7 @@
 #include <holoscan/holoscan.hpp>
 
 #include <stelline/common.hh>
+#include <stelline/store.hh>
 
 
 namespace stelline::operators::frbnn {
@@ -14,7 +15,6 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
-
 class STELLINE_API ModelPreprocessorOp : public Operator {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(ModelPreprocessorOp)
@@ -48,7 +48,7 @@ class STELLINE_API ModelPostprocessorOp : public Operator {
     void compute(InputContext& input, OutputContext& output, ExecutionContext&) override;
 };
 
-class STELLINE_API SimpleDetectionOp : public Operator {
+class STELLINE_API SimpleDetectionOp : public Operator, public stelline::StoreInterface {
  public:
        HOLOSCAN_OPERATOR_FORWARD_ARGS(SimpleDetectionOp)
 
@@ -59,6 +59,9 @@ class STELLINE_API SimpleDetectionOp : public Operator {
        void start() override;
        void stop() override;
        void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+       StoreInterface::MetricsMap collectMetricsMap() override;
+       std::string collectMetricsString() override;
 
  private:
        struct Impl;

--- a/include/stelline/operators/socket/base.hh
+++ b/include/stelline/operators/socket/base.hh
@@ -4,6 +4,7 @@
 #include <holoscan/holoscan.hpp>
 
 #include <stelline/common.hh>
+#include <stelline/store.hh>
 
 
 namespace stelline::operators::socket {
@@ -14,8 +15,7 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
-
-class STELLINE_API ZmqTransmitterOp : public Operator {
+class STELLINE_API ZmqTransmitterOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(ZmqTransmitterOp)
 
@@ -26,6 +26,9 @@ class STELLINE_API ZmqTransmitterOp : public Operator {
     void start() override;
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
 
  private:
     struct Impl;

--- a/include/stelline/operators/transport/base.hh
+++ b/include/stelline/operators/transport/base.hh
@@ -16,6 +16,7 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
+
 class STELLINE_API AtaReceiverOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(AtaReceiverOp)

--- a/include/stelline/operators/transport/base.hh
+++ b/include/stelline/operators/transport/base.hh
@@ -6,6 +6,7 @@
 #include <stelline/common.hh>
 
 #include <stelline/yaml/types/block_shape.hh>
+#include <stelline/store.hh>
 
 namespace stelline::operators::transport {
 
@@ -15,8 +16,7 @@ using holoscan::OperatorSpec;
 using holoscan::InputContext;
 using holoscan::OutputContext;
 using holoscan::ExecutionContext;
-
-class STELLINE_API AtaReceiverOp : public Operator {
+class STELLINE_API AtaReceiverOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(AtaReceiverOp)
 
@@ -27,6 +27,9 @@ class STELLINE_API AtaReceiverOp : public Operator {
     void start() override;
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
 
  private:
     struct Impl;
@@ -61,7 +64,7 @@ class STELLINE_API DummyReceiverOp : public Operator {
     Parameter<BlockShape> totalBlock_;
 };
 
-class STELLINE_API SorterOp : public Operator {
+class STELLINE_API SorterOp : public Operator, public stelline::StoreInterface {
  public:
     HOLOSCAN_OPERATOR_FORWARD_ARGS(SorterOp)
 
@@ -72,6 +75,9 @@ class STELLINE_API SorterOp : public Operator {
     void start() override;
     void stop() override;
     void compute(InputContext& input, OutputContext& output, ExecutionContext& context) override;
+
+    StoreInterface::MetricsMap collectMetricsMap() override;
+    std::string collectMetricsString() override;
 
  private:
     struct Impl;

--- a/include/stelline/store.hh
+++ b/include/stelline/store.hh
@@ -1,0 +1,23 @@
+#ifndef STELLINE_STORE_HH
+#define STELLINE_STORE_HH
+
+#include <map>
+#include <string>
+
+#include <stelline/common.hh>
+
+namespace stelline {
+
+class STELLINE_API StoreInterface {
+ public:
+    using MetricsMap = std::map<std::string, std::string>;
+
+    virtual ~StoreInterface() = default;
+
+    virtual MetricsMap collectMetricsMap() = 0;
+    virtual std::string collectMetricsString() = 0;
+};
+
+}  // namespace stelline
+
+#endif  // STELLINE_STORE_HH

--- a/include/stelline/types.hh
+++ b/include/stelline/types.hh
@@ -11,31 +11,6 @@
 
 namespace stelline {
 
-struct DspBlock {
-   uint64_t timestamp;
-   std::shared_ptr<holoscan::Tensor> tensor;
-
-    void setMetadata(const DspBlock& other) {
-        this->timestamp = other.timestamp;
-    }
-
-    void setData(const DspBlock& other) {
-        this->tensor = other.tensor;
-    }
-};
-
-struct InferenceBlock {
-    DspBlock dspBlock;
-    std::shared_ptr<holoscan::Tensor> tensor;
-
-    void setMetadata(const InferenceBlock& other) {
-    }
-
-    void data(const InferenceBlock& other) {
-        this->tensor = other.tensor;
-    }
-};
-
 typedef std::tuple<std::shared_ptr<holoscan::Operator>, std::shared_ptr<holoscan::Operator>> BitInterface;
 
 }  // namespace stelline

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'stelline',
     ['cpp', 'cuda'],
-    version: '0.1.0',
+    version: '0.2.0',
     default_options: [
         'cpp_std=c++20',
         'buildtype=release',
@@ -12,7 +12,7 @@ project(
 
 cuda = meson.get_compiler('cuda')
 is_static = get_option('default_library') == 'static'
-cdn_url = 'https://stelline.cdn.luigi.ltd/' + meson.project_version() + '/'
+cdn_url = 'https://stelline.cdn.luigi.ltd/0.0.0/'
 
 cfg_lst = configuration_data({
     'version': meson.project_version(),

--- a/python/stelline/__init__.py
+++ b/python/stelline/__init__.py
@@ -1,16 +1,14 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 import stelline.bits
 from stelline.app import App, run
 from stelline.registry import create_bit, list_bits, register_bit
-from stelline.types import BlockShape, DspBlock, InferenceBlock
+from stelline.types import BlockShape
 
 __all__ = [
     "__version__",
     "App",
     "BlockShape",
-    "DspBlock",
-    "InferenceBlock",
     "create_bit",
     "register_bit",
     "list_bits",

--- a/python/stelline/app.py
+++ b/python/stelline/app.py
@@ -5,7 +5,7 @@ Stelline Application class for building and running pipelines.
 from pathlib import Path
 
 import yaml
-from holoscan.core import Application
+from holoscan.core import Application, MetadataPolicy
 from holoscan.resources import UnboundedAllocator
 from holoscan.schedulers import (
     EventBasedScheduler,
@@ -21,6 +21,10 @@ class App(Application):
         super().__init__()
         # Configure the application
         self.config(config_path)
+
+        # Configure metadata
+        self.enable_metadata(True)
+        self.metadata_policy = MetadataPolicy.INPLACE_UPDATE
 
         # Setup scheduler based on config
         self._setup_scheduler()

--- a/python/stelline/app.py
+++ b/python/stelline/app.py
@@ -3,9 +3,9 @@ Stelline Application class for building and running pipelines.
 """
 
 from pathlib import Path
+from typing import Iterable, List
 
-import yaml
-from holoscan.core import Application, MetadataPolicy
+from holoscan.core import Application, MetadataPolicy, Operator
 from holoscan.resources import UnboundedAllocator
 from holoscan.schedulers import (
     EventBasedScheduler,
@@ -17,7 +17,12 @@ from stelline.registry import create_bit
 
 
 class App(Application):
-    def __init__(self, config_path):
+    def __init__(
+        self,
+        config_path: str,
+        metrics: bool = False,
+        metrics_interval: float = 1.0,
+    ):
         super().__init__()
         # Configure the application
         self.config(config_path)
@@ -25,6 +30,13 @@ class App(Application):
         # Configure metadata
         self.enable_metadata(True)
         self.metadata_policy = MetadataPolicy.INPLACE_UPDATE
+
+        # Metrics display configuration
+        self._metrics_enabled = metrics
+        self._metrics_interval = max(metrics_interval, 0.1)
+        self._operators: List[Operator] = []
+        self._metrics_thread = None
+        self._metrics_stop_event = None
 
         # Setup scheduler based on config
         self._setup_scheduler()
@@ -72,8 +84,86 @@ class App(Application):
             dst_in, _ = bit_map[dst_id]
             self.add_flow(src_out, dst_in)
 
+        # Determine operator ordering based on graph topology (Kahn's algorithm).
+        indegree = {node: 0 for node in bit_map.keys()}
+        adjacency = {node: [] for node in bit_map.keys()}
+        for dst_id, src_id in flows:
+            indegree[dst_id] = indegree.get(dst_id, 0) + 1
+            adjacency.setdefault(src_id, []).append(dst_id)
 
-def run(config_path: str) -> None:
+        topo_order = []
+        queue = [node for node, deg in indegree.items() if deg == 0]
+        while queue:
+            node = queue.pop(0)
+            topo_order.append(node)
+            for neighbor in adjacency.get(node, []):
+                indegree[neighbor] -= 1
+                if indegree[neighbor] == 0:
+                    queue.append(neighbor)
+
+        # Fallback to insertion order if a cycle is detected.
+        if len(topo_order) != len(bit_map):
+            topo_order = list(bit_map.keys())
+
+        ordered_ops = []
+        seen = set()
+        for node in topo_order:
+            ops = bit_map[node]
+            for op in ops:
+                if op and op not in seen:
+                    ordered_ops.append(op)
+                    seen.add(op)
+
+        self._operators = ordered_ops
+
+        if self._metrics_enabled:
+            self._start_metrics_thread()
+
+    def get_operators(self) -> Iterable[Operator]:
+        return list(self._operators)
+
+    def stop_metrics_display(self) -> None:
+        if self._metrics_thread and self._metrics_stop_event:
+            self._metrics_stop_event.set()
+            self._metrics_thread.join()
+            self._metrics_thread = None
+            self._metrics_stop_event = None
+
+    def _start_metrics_thread(self) -> None:
+        import threading
+        import time
+
+        self._metrics_stop_event = threading.Event()
+
+        def _loop():
+            while not self._metrics_stop_event.is_set():
+                timestamp = time.strftime("%H:%M:%S")
+                print(f"[{timestamp}] Metrics:")
+                for op in self._operators:
+                    try:
+                        text = op.collect_metrics_string()
+                        name = getattr(op, "name", None) or op.__class__.__name__
+                        print(f"- {name}:\n{text}")
+                    except Exception as exc:
+                        print(f"- ERROR collecting metrics: {exc}")
+                time.sleep(self._metrics_interval)
+
+        self._metrics_thread = threading.Thread(target=_loop, daemon=True)
+        self._metrics_thread.start()
+
+    def run(self) -> None:
+        try:
+            super().run()
+        finally:
+            self.stop_metrics_display()
+
+
+def run(
+    config_path: str,
+    *,
+    metrics: bool = False,
+    metrics_interval: float = 1.0,
+) -> None:
     """
     Run Stelline with the specified configuration file.
 
@@ -81,17 +171,27 @@ def run(config_path: str) -> None:
     ----------
     config_path : str
         Path to the YAML configuration file
+    metrics : bool
+        Enable periodic metrics printing.
+    metrics_interval : float
+        Seconds between metrics refreshes.
 
     Example
     -------
     import stelline as st
-    st.run("../recipes/loopback_test.yaml")
+    st.run("../recipes/loopback_test.yaml", metrics=True, metrics_interval=0.5)
     """
     if not Path(config_path).exists():
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
     print(f"Using configuration file: {config_path}")
 
-    # Create and run the application
-    app = App(config_path)
-    app.run()
+    app = App(
+        config_path,
+        metrics=metrics,
+        metrics_interval=metrics_interval,
+    )
+    try:
+        app.run()
+    finally:
+        app.stop_metrics_display()

--- a/python/stelline/bits/frbnn.py
+++ b/python/stelline/bits/frbnn.py
@@ -54,9 +54,6 @@ def FrbnnInferenceBit(
     logger.info(f"  Preprocessor Path: {frbnn_preprocessor_path}")
     logger.info(f"  Model Path: {frbnn_path}")
 
-    # Configure app for metadata
-    app.is_metadata_enabled(True)
-
     # Build FRBNN Preprocessor configuration
     frbnn_preprocessor_path_map = {"frbnn_preprocessor": frbnn_preprocessor_path}
     frbnn_preprocessor_input_map = {"frbnn_preprocessor": ["input"]}
@@ -167,9 +164,6 @@ def FrbnnDetectionBit(
     logger.info("FRBNN Detection Configuration:")
     logger.info(f"  CSV File Path: {csv_file_path}")
     logger.info(f"  Hits Directory: {hits_directory}")
-
-    # Configure app for metadata
-    app.is_metadata_enabled(True)
 
     # Create detection operator
     frbnn_simple_detection_name = f"frbnn-simple-detection-{id}"

--- a/python/stelline/scripts/run.py
+++ b/python/stelline/scripts/run.py
@@ -29,6 +29,17 @@ def run_parser(subparsers):
         action="append",
         help="Python files containing custom bit definitions to load (can be used multiple times)",
     )
+    parser.add_argument(
+        "--metrics",
+        action="store_true",
+        help="Enable periodic metrics printing",
+    )
+    parser.add_argument(
+        "--metrics-interval",
+        type=float,
+        default=1.0,
+        help="Seconds between metrics refreshes (default: 1.0)",
+    )
     return parser
 
 
@@ -64,5 +75,9 @@ def run_command(args):
             spec.loader.exec_module(module)
 
     # Create and run the application
-    app = App(args.config)
+    app = App(
+        args.config,
+        metrics=args.metrics,
+        metrics_interval=args.metrics_interval,
+    )
     app.run()

--- a/python/stelline/types.py
+++ b/python/stelline/types.py
@@ -1,3 +1,3 @@
-from stelline._types import BlockShape, DspBlock, InferenceBlock
+from stelline._types import BlockShape
 
-__all__ = ["BlockShape", "DspBlock", "InferenceBlock"]
+__all__ = ["BlockShape"]

--- a/src/bindings/operators/blade_ops.cc
+++ b/src/bindings/operators/blade_ops.cc
@@ -90,7 +90,9 @@ PYBIND11_MODULE(_blade_ops, m) {
              py::arg("input_shape"),
              py::arg("output_shape"),
              py::arg("options"),
-             py::arg("name") = "correlator");
+             py::arg("name") = "correlator")
+        .def("collect_metrics_map", &CorrelatorOp::collectMetricsMap)
+        .def("collect_metrics_string", &CorrelatorOp::collectMetricsString);
 
     py::class_<BeamformerOp, PyBeamformerOp, Operator, std::shared_ptr<BeamformerOp>>(m, "BeamformerOp")
         .def(py::init<Fragment*, const py::args&, uint64_t, const stelline::BlockShape&,
@@ -100,7 +102,9 @@ PYBIND11_MODULE(_blade_ops, m) {
              py::arg("input_shape"),
              py::arg("output_shape"),
              py::arg("options"),
-             py::arg("name") = "beamformer");
+             py::arg("name") = "beamformer")
+        .def("collect_metrics_map", &BeamformerOp::collectMetricsMap)
+        .def("collect_metrics_string", &BeamformerOp::collectMetricsString);
 
     py::class_<FrbnnOp, PyFrbnnOp, Operator, std::shared_ptr<FrbnnOp>>(m, "FrbnnOp")
         .def(py::init<Fragment*, const py::args&, uint64_t, const stelline::BlockShape&,
@@ -110,5 +114,7 @@ PYBIND11_MODULE(_blade_ops, m) {
              py::arg("input_shape"),
              py::arg("output_shape"),
              py::arg("options"),
-             py::arg("name") = "frbnn");
+             py::arg("name") = "frbnn")
+        .def("collect_metrics_map", &FrbnnOp::collectMetricsMap)
+        .def("collect_metrics_string", &FrbnnOp::collectMetricsString);
 }

--- a/src/bindings/operators/filesystem_ops.cc
+++ b/src/bindings/operators/filesystem_ops.cc
@@ -106,26 +106,34 @@ PYBIND11_MODULE(_filesystem_ops, m) {
     py::class_<DummyWriterOp, PyDummyWriterOp, Operator, std::shared_ptr<DummyWriterOp>>(m, "DummyWriterOp")
         .def(py::init<Fragment*, const py::args&, const std::string&>(),
              py::arg("fragment"),
-             py::arg("name") = "dummy_writer");
+             py::arg("name") = "dummy_writer")
+        .def("collect_metrics_map", &DummyWriterOp::collectMetricsMap)
+        .def("collect_metrics_string", &DummyWriterOp::collectMetricsString);
 
     py::class_<SimpleWriterOp, PySimpleWriterOp, Operator, std::shared_ptr<SimpleWriterOp>>(m, "SimpleWriterOp")
         .def(py::init<Fragment*, const py::args&, const std::string&, const std::string&>(),
              py::arg("fragment"),
              py::arg("file_path"),
-             py::arg("name") = "simple_writer");
+             py::arg("name") = "simple_writer")
+        .def("collect_metrics_map", &SimpleWriterOp::collectMetricsMap)
+        .def("collect_metrics_string", &SimpleWriterOp::collectMetricsString);
 
     py::class_<SimpleWriterRdmaOp, PySimpleWriterRdmaOp, Operator, std::shared_ptr<SimpleWriterRdmaOp>>(m, "SimpleWriterRdmaOp")
         .def(py::init<Fragment*, const py::args&, const std::string&, const std::string&>(),
              py::arg("fragment"),
              py::arg("file_path"),
-             py::arg("name") = "simple_writer_rdma");
+             py::arg("name") = "simple_writer_rdma")
+        .def("collect_metrics_map", &SimpleWriterRdmaOp::collectMetricsMap)
+        .def("collect_metrics_string", &SimpleWriterRdmaOp::collectMetricsString);
 
 #ifdef STELLINE_LOADER_FBH5
     py::class_<Fbh5WriterRdmaOp, PyFbh5WriterRdmaOp, Operator, std::shared_ptr<Fbh5WriterRdmaOp>>(m, "Fbh5WriterRdmaOp")
         .def(py::init<Fragment*, const py::args&, const std::string&, const std::string&>(),
              py::arg("fragment"),
              py::arg("file_path"),
-             py::arg("name") = "fbh5_writer_rdma");
+             py::arg("name") = "fbh5_writer_rdma")
+        .def("collect_metrics_map", &Fbh5WriterRdmaOp::collectMetricsMap)
+        .def("collect_metrics_string", &Fbh5WriterRdmaOp::collectMetricsString);
 #endif
 
 #ifdef STELLINE_LOADER_UVH5
@@ -137,6 +145,8 @@ PYBIND11_MODULE(_filesystem_ops, m) {
              py::arg("telinfo_file_path"),
              py::arg("obsantinfo_file_path"),
              py::arg("iers_file_path"),
-             py::arg("name") = "uvh5_writer_rdma");
+             py::arg("name") = "uvh5_writer_rdma")
+        .def("collect_metrics_map", &Uvh5WriterRdmaOp::collectMetricsMap)
+        .def("collect_metrics_string", &Uvh5WriterRdmaOp::collectMetricsString);
 #endif
 }

--- a/src/bindings/operators/frbnn_ops.cc
+++ b/src/bindings/operators/frbnn_ops.cc
@@ -97,5 +97,7 @@ PYBIND11_MODULE(_frbnn_ops, m) {
              py::arg("fragment"),
              py::arg("csv_file_path"),
              py::arg("hits_directory"),
-             py::arg("name") = "simple_detection");
+             py::arg("name") = "simple_detection")
+        .def("collect_metrics_map", &SimpleDetectionOp::collectMetricsMap)
+        .def("collect_metrics_string", &SimpleDetectionOp::collectMetricsString);
 }

--- a/src/bindings/operators/socket_ops.cc
+++ b/src/bindings/operators/socket_ops.cc
@@ -34,5 +34,7 @@ PYBIND11_MODULE(_socket_ops, m) {
         .def(py::init<Fragment*, const py::args&, const std::string&, const std::string&>(),
              py::arg("fragment"),
              py::arg("address"),
-             py::arg("name") = "zmq_transmitter");
+             py::arg("name") = "zmq_transmitter")
+        .def("collect_metrics_map", &ZmqTransmitterOp::collectMetricsMap)
+        .def("collect_metrics_string", &ZmqTransmitterOp::collectMetricsString);
 }

--- a/src/bindings/operators/transport_ops.cc
+++ b/src/bindings/operators/transport_ops.cc
@@ -223,7 +223,9 @@ PYBIND11_MODULE(_transport_ops, m) {
              py::arg("offset_block"),
              py::arg("output_pool_size"),
              py::arg("enable_csv_logging"),
-             py::arg("name") = "ata_receiver");
+             py::arg("name") = "ata_receiver")
+        .def("collect_metrics_map", &AtaReceiverOp::collectMetricsMap)
+        .def("collect_metrics_string", &AtaReceiverOp::collectMetricsString);
 
     py::class_<DummyReceiverOp, PyDummyReceiverOp, Operator, std::shared_ptr<DummyReceiverOp>>(m, "DummyReceiverOp")
         .def(py::init<Fragment*,
@@ -241,5 +243,7 @@ PYBIND11_MODULE(_transport_ops, m) {
                       const std::string&>(),
              py::arg("fragment"),
              py::arg("depth"),
-             py::arg("name") = "sorter");
+             py::arg("name") = "sorter")
+        .def("collect_metrics_map", &SorterOp::collectMetricsMap)
+        .def("collect_metrics_string", &SorterOp::collectMetricsString);
 }

--- a/src/bindings/types.cc
+++ b/src/bindings/types.cc
@@ -26,23 +26,4 @@ PYBIND11_MODULE(_types, m) {
                              b.numberOfAntennas, b.numberOfChannels,
                              b.numberOfSamples, b.numberOfPolarizations);
         });
-
-    py::class_<DspBlock, std::shared_ptr<DspBlock>>(m, "DspBlock")
-        .def(py::init<>())
-        .def_readwrite("timestamp", &DspBlock::timestamp)
-        .def_readwrite("tensor", &DspBlock::tensor)
-        .def("set_metadata", &DspBlock::setMetadata)
-        .def("set_data", &DspBlock::setData)
-        .def("__repr__", [](const DspBlock& d) {
-            return fmt::format("DspBlock(timestamp={})", d.timestamp);
-        });
-
-    py::class_<InferenceBlock, std::shared_ptr<InferenceBlock>>(m, "InferenceBlock")
-        .def(py::init<>())
-        .def_readwrite("dsp_block", &InferenceBlock::dspBlock)
-        .def_readwrite("tensor", &InferenceBlock::tensor)
-        .def("set_metadata", &InferenceBlock::setMetadata)
-        .def("__repr__", [](const InferenceBlock&) {
-            return "InferenceBlock()";
-        });
 }

--- a/src/operators/blade/beamformer.cc
+++ b/src/operators/blade/beamformer.cc
@@ -209,6 +209,9 @@ void BeamformerOp::compute(InputContext& input, OutputContext& output, Execution
 }
 
 stelline::StoreInterface::MetricsMap BeamformerOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     const auto stats = pimpl->dispatcher.metrics();
     stelline::StoreInterface::MetricsMap metrics;
     metrics["successful_enqueues"] = fmt::format("{}", stats.successfulEnqueues);
@@ -220,20 +223,21 @@ stelline::StoreInterface::MetricsMap BeamformerOp::collectMetricsMap() {
 }
 
 std::string BeamformerOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format(
-        "Beamformer Operator:\n"
-        "  Queueing Statistics:\n"
-        "    Successful Enqueues: {}\n"
-        "    Successful Dequeues: {}\n"
-        "    Full Enqueues: {}\n"
-        "    Dequeue Retries: {}\n"
-        "    Premature Dequeues: {}",
-        metrics.at("successful_enqueues"),
-        metrics.at("successful_dequeues"),
-        metrics.at("full_enqueues"),
-        metrics.at("dequeue_retries"),
-        metrics.at("premature_dequeues"));
+    return fmt::format("  Queueing Statistics:\n"
+                       "    Successful Enqueues: {}\n"
+                       "    Successful Dequeues: {}\n"
+                       "    Full Enqueues: {}\n"
+                       "    Dequeue Retries: {}\n"
+                       "    Premature Dequeues: {}",
+                       metrics.at("successful_enqueues"),
+                       metrics.at("successful_dequeues"),
+                       metrics.at("full_enqueues"),
+                       metrics.at("dequeue_retries"),
+                       metrics.at("premature_dequeues"));
 }
 
 }  // namespace stelline::operators::blade

--- a/src/operators/blade/beamformer.cc
+++ b/src/operators/blade/beamformer.cc
@@ -127,10 +127,10 @@ BeamformerOp::~BeamformerOp() {
 }
 
 void BeamformerOp::setup(OperatorSpec& spec) {
-    spec.input<DspBlock>("dsp_block_in")
+    spec.input<std::shared_ptr<holoscan::Tensor>>("dsp_block_in")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
-    spec.output<DspBlock>("dsp_block_out")
+    spec.output<std::shared_ptr<holoscan::Tensor>>("dsp_block_out")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
 
@@ -199,28 +199,29 @@ void BeamformerOp::stop() {
 
 void BeamformerOp::compute(InputContext& input, OutputContext& output, ExecutionContext&) {
     auto receiveCallback = [&](){
-        return input.receive<DspBlock>("dsp_block_in").value();
+        return input.receive<std::shared_ptr<holoscan::Tensor>>("dsp_block_in").value();
     };
 
-    auto convertInputCallback = [&](DspBlock& data){
-        ArrayTensor<Device::CUDA, CF32> deviceInputBuffer(data.tensor->data(), pimpl->config.inputShape);
+    auto convertInputCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        ArrayTensor<Device::CUDA, CF32> deviceInputBuffer(tensor->data(), pimpl->config.inputShape);
         return pimpl->pipeline->transferIn(deviceInputBuffer);
     };
 
-    auto convertOutputCallback = [&](DspBlock& data){
-        ArrayTensor<Device::CUDA, CF32> deviceOutputBuffer(data.tensor->data(), pimpl->config.outputShape);
+    auto convertOutputCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        ArrayTensor<Device::CUDA, CF32> deviceOutputBuffer(tensor->data(), pimpl->config.outputShape);
         return pimpl->pipeline->transferOut(deviceOutputBuffer);
     };
 
-    auto emitCallback = [&](DspBlock& data){
-        output.emit(data, "dsp_block_out");
+    auto emitCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        output.emit(tensor, "dsp_block_out");
     };
 
     if (pimpl->dispatcher.run(pimpl->pipeline,
                               receiveCallback,
                               convertInputCallback,
                               convertOutputCallback,
-                              emitCallback) != Result::SUCCESS) {
+                              emitCallback,
+                              metadata()) != Result::SUCCESS) {
         throw std::runtime_error("Dispatcher failed.");
     }
 }

--- a/src/operators/blade/correlator.cc
+++ b/src/operators/blade/correlator.cc
@@ -3,6 +3,7 @@
 
 #include <stelline/operators/blade/base.hh>
 #include <stelline/types.hh>
+#include <fmt/format.h>
 
 #include "utils/dispatcher.hh"
 
@@ -63,12 +64,6 @@ struct CorrelatorOp::Impl {
     Dispatcher dispatcher;
     OpCorrelatorPipeline::Config config;
     std::shared_ptr<OpCorrelatorPipeline> pipeline;
-
-    // Metrics.
-
-    std::thread metricsThread;
-    bool metricsThreadRunning;
-    void metricsLoop();
 };
 
 void CorrelatorOp::initialize() {
@@ -151,22 +146,9 @@ void CorrelatorOp::start() {
 
     // TODO: Make number of buffers configurable.
     pimpl->dispatcher.template initialize<CF32>(pimpl->numberOfBuffers, pimpl->config.outputShape);
-
-    // Start metrics thread.
-
-    pimpl->metricsThreadRunning = true;
-    pimpl->metricsThread = std::thread([&]{
-        pimpl->metricsLoop();
-    });
 }
 
 void CorrelatorOp::stop() {
-    // Stop metrics thread.
-
-    pimpl->metricsThreadRunning = false;
-    if (pimpl->metricsThread.joinable()) {
-        pimpl->metricsThread.join();
-    }
 }
 
 void CorrelatorOp::compute(InputContext& input, OutputContext& output, ExecutionContext&) {
@@ -198,13 +180,32 @@ void CorrelatorOp::compute(InputContext& input, OutputContext& output, Execution
     }
 }
 
-void CorrelatorOp::Impl::metricsLoop() {
-    while (metricsThreadRunning) {
-        HOLOSCAN_LOG_INFO("Correlator Operator:");
-        dispatcher.metrics();
+stelline::StoreInterface::MetricsMap CorrelatorOp::collectMetricsMap() {
+    const auto stats = pimpl->dispatcher.metrics();
+    stelline::StoreInterface::MetricsMap metrics;
+    metrics["successful_enqueues"] = fmt::format("{}", stats.successfulEnqueues);
+    metrics["successful_dequeues"] = fmt::format("{}", stats.successfulDequeues);
+    metrics["full_enqueues"] = fmt::format("{}", stats.fullEnqueues);
+    metrics["dequeue_retries"] = fmt::format("{}", stats.dequeueRetries);
+    metrics["premature_dequeues"] = fmt::format("{}", stats.prematureDequeues);
+    return metrics;
+}
 
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
+std::string CorrelatorOp::collectMetricsString() {
+    const auto metrics = collectMetricsMap();
+    return fmt::format(
+        "Correlator Operator:\n"
+        "  Queueing Statistics:\n"
+        "    Successful Enqueues: {}\n"
+        "    Successful Dequeues: {}\n"
+        "    Full Enqueues: {}\n"
+        "    Dequeue Retries: {}\n"
+        "    Premature Dequeues: {}",
+        metrics.at("successful_enqueues"),
+        metrics.at("successful_dequeues"),
+        metrics.at("full_enqueues"),
+        metrics.at("dequeue_retries"),
+        metrics.at("premature_dequeues"));
 }
 
 }  // namespace stelline::operators::blade

--- a/src/operators/blade/correlator.cc
+++ b/src/operators/blade/correlator.cc
@@ -181,6 +181,9 @@ void CorrelatorOp::compute(InputContext& input, OutputContext& output, Execution
 }
 
 stelline::StoreInterface::MetricsMap CorrelatorOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     const auto stats = pimpl->dispatcher.metrics();
     stelline::StoreInterface::MetricsMap metrics;
     metrics["successful_enqueues"] = fmt::format("{}", stats.successfulEnqueues);
@@ -192,20 +195,21 @@ stelline::StoreInterface::MetricsMap CorrelatorOp::collectMetricsMap() {
 }
 
 std::string CorrelatorOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format(
-        "Correlator Operator:\n"
-        "  Queueing Statistics:\n"
-        "    Successful Enqueues: {}\n"
-        "    Successful Dequeues: {}\n"
-        "    Full Enqueues: {}\n"
-        "    Dequeue Retries: {}\n"
-        "    Premature Dequeues: {}",
-        metrics.at("successful_enqueues"),
-        metrics.at("successful_dequeues"),
-        metrics.at("full_enqueues"),
-        metrics.at("dequeue_retries"),
-        metrics.at("premature_dequeues"));
+    return fmt::format("  Queueing Statistics:\n"
+                       "    Successful Enqueues: {}\n"
+                       "    Successful Dequeues: {}\n"
+                       "    Full Enqueues: {}\n"
+                       "    Dequeue Retries: {}\n"
+                       "    Premature Dequeues: {}",
+                       metrics.at("successful_enqueues"),
+                       metrics.at("successful_dequeues"),
+                       metrics.at("full_enqueues"),
+                       metrics.at("dequeue_retries"),
+                       metrics.at("premature_dequeues"));
 }
 
 }  // namespace stelline::operators::blade

--- a/src/operators/blade/frbnn.cc
+++ b/src/operators/blade/frbnn.cc
@@ -295,6 +295,9 @@ void FrbnnOp::compute(InputContext& input, OutputContext& output, ExecutionConte
 }
 
 stelline::StoreInterface::MetricsMap FrbnnOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     const auto stats = pimpl->dispatcher.metrics();
     stelline::StoreInterface::MetricsMap metrics;
     metrics["successful_enqueues"] = fmt::format("{}", stats.successfulEnqueues);
@@ -306,20 +309,21 @@ stelline::StoreInterface::MetricsMap FrbnnOp::collectMetricsMap() {
 }
 
 std::string FrbnnOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format(
-        "Frbnn Operator:\n"
-        "  Queueing Statistics:\n"
-        "    Successful Enqueues: {}\n"
-        "    Successful Dequeues: {}\n"
-        "    Full Enqueues: {}\n"
-        "    Dequeue Retries: {}\n"
-        "    Premature Dequeues: {}",
-        metrics.at("successful_enqueues"),
-        metrics.at("successful_dequeues"),
-        metrics.at("full_enqueues"),
-        metrics.at("dequeue_retries"),
-        metrics.at("premature_dequeues"));
+    return fmt::format("  Queueing Statistics:\n"
+                       "    Successful Enqueues: {}\n"
+                       "    Successful Dequeues: {}\n"
+                       "    Full Enqueues: {}\n"
+                       "    Dequeue Retries: {}\n"
+                       "    Premature Dequeues: {}",
+                       metrics.at("successful_enqueues"),
+                       metrics.at("successful_dequeues"),
+                       metrics.at("full_enqueues"),
+                       metrics.at("dequeue_retries"),
+                       metrics.at("premature_dequeues"));
 }
 
 }  // namespace stelline::operators::blade

--- a/src/operators/blade/frbnn.cc
+++ b/src/operators/blade/frbnn.cc
@@ -202,10 +202,10 @@ FrbnnOp::~FrbnnOp() {
 }
 
 void FrbnnOp::setup(OperatorSpec& spec) {
-    spec.input<DspBlock>("dsp_block_in")
+    spec.input<std::shared_ptr<holoscan::Tensor>>("dsp_block_in")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
-    spec.output<DspBlock>("dsp_block_out")
+    spec.output<std::shared_ptr<holoscan::Tensor>>("dsp_block_out")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
 
@@ -285,28 +285,29 @@ void FrbnnOp::stop() {
 
 void FrbnnOp::compute(InputContext& input, OutputContext& output, ExecutionContext&) {
     auto receiveCallback = [&](){
-        return input.receive<DspBlock>("dsp_block_in").value();
+        return input.receive<std::shared_ptr<holoscan::Tensor>>("dsp_block_in").value();
     };
 
-    auto convertInputCallback = [&](DspBlock& data){
-        ArrayTensor<Device::CUDA, CF32> deviceInputBuffer(data.tensor->data(), pimpl->config.inputShape);
+    auto convertInputCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        ArrayTensor<Device::CUDA, CF32> deviceInputBuffer(tensor->data(), pimpl->config.inputShape);
         return pimpl->pipeline->transferIn(deviceInputBuffer);
     };
 
-    auto convertOutputCallback = [&](DspBlock& data){
-        ArrayTensor<Device::CUDA, F32> deviceOutputBuffer(data.tensor->data(), pimpl->config.outputShape);
+    auto convertOutputCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        ArrayTensor<Device::CUDA, F32> deviceOutputBuffer(tensor->data(), pimpl->config.outputShape);
         return pimpl->pipeline->transferOut(deviceOutputBuffer);
     };
 
-    auto emitCallback = [&](DspBlock& data){
-        output.emit(data, "dsp_block_out");
+    auto emitCallback = [&](std::shared_ptr<holoscan::Tensor>& tensor){
+        output.emit(tensor, "dsp_block_out");
     };
 
     if (pimpl->dispatcher.run(pimpl->pipeline,
                               receiveCallback,
                               convertInputCallback,
                               convertOutputCallback,
-                              emitCallback) != Result::SUCCESS) {
+                              emitCallback,
+                              metadata()) != Result::SUCCESS) {
         throw std::runtime_error("Dispatcher failed.");
     }
 }

--- a/src/operators/blade/utils/dispatcher.hh
+++ b/src/operators/blade/utils/dispatcher.hh
@@ -212,13 +212,22 @@ class Dispatcher {
         return Result::SUCCESS;
     };
 
-    void metrics() {
-        HOLOSCAN_LOG_INFO("  Queueing Statistics:");
-        HOLOSCAN_LOG_INFO("    Successful Enqueues: {}", numberOfSuccessfulEnqueues);
-        HOLOSCAN_LOG_INFO("    Successful Dequeues: {}", numberOfSuccessfulDequeues);
-        HOLOSCAN_LOG_INFO("    Full Enqueues: {}", numberOfFullEnqueues);
-        HOLOSCAN_LOG_INFO("    Dequeue Retries: {}", numberOfDequeueRetries);
-        HOLOSCAN_LOG_INFO("    Premature Dequeues: {}", numberOfPrematureDequeues);
+    struct Metrics {
+        U64 successfulEnqueues;
+        U64 successfulDequeues;
+        U64 fullEnqueues;
+        U64 dequeueRetries;
+        U64 prematureDequeues;
+    };
+
+    Metrics metrics() const {
+        return {
+            numberOfSuccessfulEnqueues,
+            numberOfSuccessfulDequeues,
+            numberOfFullEnqueues,
+            numberOfDequeueRetries,
+            numberOfPrematureDequeues
+        };
     }
 
  private:

--- a/src/operators/filesystem/dummy_writer.cc
+++ b/src/operators/filesystem/dummy_writer.cc
@@ -78,6 +78,9 @@ void DummyWriterOp::compute(InputContext& input, OutputContext&, ExecutionContex
 }
 
 stelline::StoreInterface::MetricsMap DummyWriterOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     stelline::StoreInterface::MetricsMap metrics;
     metrics["iterations"] = fmt::format("{}", pimpl->numIterations);
     metrics["average_duration_ms"] = fmt::format("{}", pimpl->duration.count() / 100);
@@ -86,9 +89,11 @@ stelline::StoreInterface::MetricsMap DummyWriterOp::collectMetricsMap() {
 }
 
 std::string DummyWriterOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("Dummy Writer Operator:\n"
-                       "  Iterations      : {}\n"
+    return fmt::format("  Iterations      : {}\n"
                        "  Average Duration: {} ms\n"
                        "  Latest Timestamp: {}",
                        metrics.at("iterations"),

--- a/src/operators/filesystem/fbh5_writer_rdma.cc
+++ b/src/operators/filesystem/fbh5_writer_rdma.cc
@@ -209,6 +209,9 @@ void Fbh5WriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionCon
 }
 
 stelline::StoreInterface::MetricsMap Fbh5WriterRdmaOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     auto now = std::chrono::steady_clock::now();
     auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
@@ -226,9 +229,11 @@ stelline::StoreInterface::MetricsMap Fbh5WriterRdmaOp::collectMetricsMap() {
 }
 
 std::string Fbh5WriterRdmaOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("HDF5 Sink RDMA Operator:\n"
-                       "  Current Bandwidth: {} MB/s\n"
+    return fmt::format("  Current Bandwidth: {} MB/s\n"
                        "  Total Data Written: {} MB\n"
                        "  Chunks Written: {}",
                        metrics.at("current_bandwidth_mb_s"),

--- a/src/operators/filesystem/simple_writer.cc
+++ b/src/operators/filesystem/simple_writer.cc
@@ -5,6 +5,7 @@
 
 #include <stelline/types.hh>
 #include <stelline/operators/filesystem/base.hh>
+#include <fmt/format.h>
 
 #include "utils/helpers.hh"
 #include "utils/modifiers.hh"
@@ -29,10 +30,6 @@ struct SimpleWriterOp::Impl {
     std::chrono::time_point<std::chrono::steady_clock> lastMeasurementTime;
     std::atomic<int64_t> bytesSinceLastMeasurement{0};
     std::atomic<double> currentBandwidthMBps{0.0};
-
-    std::thread metricsThread;
-    bool metricsThreadRunning;
-    void metricsLoop();
 };
 
 void SimpleWriterOp::initialize() {
@@ -73,24 +70,10 @@ void SimpleWriterOp::start() {
     pimpl->lastMeasurementTime = std::chrono::steady_clock::now();
     pimpl->currentBandwidthMBps = 0.0;
 
-    // Start metrics thread.
-
-    pimpl->metricsThreadRunning = true;
-    pimpl->metricsThread = std::thread([&]{
-        pimpl->metricsLoop();
-    });
-
     HOLOSCAN_LOG_INFO("Successfully opened file '{}'.", pimpl->filePath);
 }
 
 void SimpleWriterOp::stop() {
-    // Stop metrics thread.
-
-    pimpl->metricsThreadRunning = false;
-    if (pimpl->metricsThread.joinable()) {
-        pimpl->metricsThread.join();
-    }
-
     // Deallocate host bounce buffer.
 
     if (pimpl->bounceBuffer != nullptr) {
@@ -151,23 +134,29 @@ void SimpleWriterOp::compute(InputContext& input, OutputContext&, ExecutionConte
     pimpl->bytesSinceLastMeasurement += tensorBytes;
 }
 
-void SimpleWriterOp::Impl::metricsLoop() {
-    while (metricsThreadRunning) {
-        auto now = std::chrono::steady_clock::now();
-        auto elapsedSeconds = std::chrono::duration<double>(now - lastMeasurementTime).count();
+stelline::StoreInterface::MetricsMap SimpleWriterOp::collectMetricsMap() {
+    auto now = std::chrono::steady_clock::now();
+    auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
-        if (elapsedSeconds > 0.0) {
-            int64_t bytes = bytesSinceLastMeasurement.exchange(0);
-            currentBandwidthMBps = static_cast<double>(bytes) / (1024.0 * 1024.0) / elapsedSeconds;
-            lastMeasurementTime = now;
-        }
-
-        HOLOSCAN_LOG_INFO("Simple Writer Operator:");
-        HOLOSCAN_LOG_INFO("  Current Bandwidth: {:.2f} MB/s", currentBandwidthMBps.load());
-        HOLOSCAN_LOG_INFO("  Total Data Written: {:.0f} MB", static_cast<double>(bytesWritten) / (1024.0 * 1024.0));
-
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (elapsedSeconds > 0.0) {
+        int64_t bytes = pimpl->bytesSinceLastMeasurement.exchange(0);
+        pimpl->currentBandwidthMBps = static_cast<double>(bytes) / (1024.0 * 1024.0) / elapsedSeconds;
+        pimpl->lastMeasurementTime = now;
     }
+
+    stelline::StoreInterface::MetricsMap metrics;
+    metrics["current_bandwidth_mb_s"] = fmt::format("{:.2f}", pimpl->currentBandwidthMBps.load());
+    metrics["total_data_written_mb"] = fmt::format("{:.0f}", static_cast<double>(pimpl->bytesWritten) / (1024.0 * 1024.0));
+    return metrics;
+}
+
+std::string SimpleWriterOp::collectMetricsString() {
+    const auto metrics = collectMetricsMap();
+    return fmt::format("Simple Writer Operator:\n"
+                       "  Current Bandwidth: {} MB/s\n"
+                       "  Total Data Written: {} MB",
+                       metrics.at("current_bandwidth_mb_s"),
+                       metrics.at("total_data_written_mb"));
 }
 
 }  // namespace stelline::operators::filesystem

--- a/src/operators/filesystem/simple_writer.cc
+++ b/src/operators/filesystem/simple_writer.cc
@@ -135,6 +135,9 @@ void SimpleWriterOp::compute(InputContext& input, OutputContext&, ExecutionConte
 }
 
 stelline::StoreInterface::MetricsMap SimpleWriterOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     auto now = std::chrono::steady_clock::now();
     auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
@@ -151,9 +154,11 @@ stelline::StoreInterface::MetricsMap SimpleWriterOp::collectMetricsMap() {
 }
 
 std::string SimpleWriterOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("Simple Writer Operator:\n"
-                       "  Current Bandwidth: {} MB/s\n"
+    return fmt::format("  Current Bandwidth: {} MB/s\n"
                        "  Total Data Written: {} MB",
                        metrics.at("current_bandwidth_mb_s"),
                        metrics.at("total_data_written_mb"));

--- a/src/operators/filesystem/simple_writer_rdma.cc
+++ b/src/operators/filesystem/simple_writer_rdma.cc
@@ -151,6 +151,9 @@ void SimpleWriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionC
 }
 
 stelline::StoreInterface::MetricsMap SimpleWriterRdmaOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     auto now = std::chrono::steady_clock::now();
     auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
@@ -167,9 +170,11 @@ stelline::StoreInterface::MetricsMap SimpleWriterRdmaOp::collectMetricsMap() {
 }
 
 std::string SimpleWriterRdmaOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("Simple Writer RDMA Operator:\n"
-                       "  Current Bandwidth: {} MB/s\n"
+    return fmt::format("  Current Bandwidth: {} MB/s\n"
                        "  Total Data Written: {} MB",
                        metrics.at("current_bandwidth_mb_s"),
                        metrics.at("total_data_written_mb"));

--- a/src/operators/filesystem/utils/modifiers.cc
+++ b/src/operators/filesystem/utils/modifiers.cc
@@ -13,7 +13,7 @@ auto CreateTensor(auto& t) {
     return std::make_shared<holoscan::Tensor>(tensor.ToDlPack());
 }
 
-cudaError DspBlockAlloc(const std::shared_ptr<holoscan::Tensor>& tensor,
+cudaError BlockAlloc(const std::shared_ptr<holoscan::Tensor>& tensor,
                         std::shared_ptr<holoscan::Tensor>& permutedTensor) {
     switch (tensor->dtype().code) {
         case 2:  //kDLFloat:
@@ -23,7 +23,7 @@ cudaError DspBlockAlloc(const std::shared_ptr<holoscan::Tensor>& tensor,
             permutedTensor = CreateTensor<cuda::std::complex<float>>(tensor);
             break;
         default:
-            HOLOSCAN_LOG_ERROR("DspBlockAlloc: Unsupported data type");
+            HOLOSCAN_LOG_ERROR("BlockAlloc: Unsupported data type");
             return cudaErrorNotSupported;
     }
 

--- a/src/operators/filesystem/utils/modifiers.cu
+++ b/src/operators/filesystem/utils/modifiers.cu
@@ -17,7 +17,7 @@ cudaError_t Permutation(DLManagedTensor* dst, const DLManagedTensor* src) {
 
 namespace stelline::operators::filesystem {
 
-cudaError_t DspBlockPermutation(DLManagedTensor* dst, const DLManagedTensor* src) {
+cudaError_t BlockPermutation(DLManagedTensor* dst, const DLManagedTensor* src) {
     if (src->dl_tensor.ndim != 4) {
         return cudaErrorInvalidValue;
     }

--- a/src/operators/filesystem/utils/modifiers.hh
+++ b/src/operators/filesystem/utils/modifiers.hh
@@ -12,12 +12,12 @@
 namespace stelline::operators::filesystem {
 
 #ifndef __CUDACC__
-cudaError DspBlockAlloc(const std::shared_ptr<holoscan::Tensor>& tensor,
+cudaError BlockAlloc(const std::shared_ptr<holoscan::Tensor>& tensor,
                         std::shared_ptr<holoscan::Tensor>& permutedTensor);
 #endif  // __CUDACC__
 
-cudaError_t DspBlockPermutation(DLManagedTensor* dst, const DLManagedTensor* src);
-// TODO: Add DspBlockTypeCast method.
+cudaError_t BlockPermutation(DLManagedTensor* dst, const DLManagedTensor* src);
+// TODO: Add BlockTypeCast method.
 
 }  // namespace stelline::operators::filesystem
 

--- a/src/operators/filesystem/uvh5_writer_rdma.cc
+++ b/src/operators/filesystem/uvh5_writer_rdma.cc
@@ -65,7 +65,7 @@ Uvh5WriterRdmaOp::~Uvh5WriterRdmaOp() {
 }
 
 void Uvh5WriterRdmaOp::setup(OperatorSpec& spec) {
-    spec.input<DspBlock>("in")
+    spec.input<std::shared_ptr<holoscan::Tensor>>("in")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
 
@@ -207,13 +207,13 @@ void Uvh5WriterRdmaOp::stop() {
 }
 
 void Uvh5WriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionContext&) {
-    const auto& tensor = input.receive<DspBlock>("in").value().tensor;
+    const auto& tensor = input.receive<std::shared_ptr<holoscan::Tensor>>("in").value();
     const auto& tensorBytes = tensor->size() * (tensor->dtype().bits / 8);
 
     // Allocate permuted tensor.
 
     if (pimpl->bytesWritten == 0) {
-        CUDA_CHECK_THROW(DspBlockAlloc(tensor, pimpl->permutedTensor), [&]{
+        CUDA_CHECK_THROW(BlockAlloc(tensor, pimpl->permutedTensor), [&]{
             HOLOSCAN_LOG_ERROR("Failed to allocate permuted tensor.");
         });
 
@@ -224,7 +224,7 @@ void Uvh5WriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionCon
 
     // Permute tensor.
 
-    CUDA_CHECK_THROW(DspBlockPermutation(pimpl->permutedTensor->to_dlpack(), tensor->to_dlpack()), [&]{
+    CUDA_CHECK_THROW(BlockPermutation(pimpl->permutedTensor->to_dlpack(), tensor->to_dlpack()), [&]{
         HOLOSCAN_LOG_ERROR("Failed to permute tensor.");
     });
 

--- a/src/operators/filesystem/uvh5_writer_rdma.cc
+++ b/src/operators/filesystem/uvh5_writer_rdma.cc
@@ -293,6 +293,9 @@ void Uvh5WriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionCon
 }
 
 stelline::StoreInterface::MetricsMap Uvh5WriterRdmaOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     auto now = std::chrono::steady_clock::now();
     auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
@@ -310,9 +313,11 @@ stelline::StoreInterface::MetricsMap Uvh5WriterRdmaOp::collectMetricsMap() {
 }
 
 std::string Uvh5WriterRdmaOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("HDF5 Sink RDMA Operator:\n"
-                       "  Current Bandwidth: {} MB/s\n"
+    return fmt::format("  Current Bandwidth: {} MB/s\n"
                        "  Total Data Written: {} MB\n"
                        "  Chunks Written: {}",
                        metrics.at("current_bandwidth_mb_s"),

--- a/src/operators/filesystem/uvh5_writer_rdma.cc
+++ b/src/operators/filesystem/uvh5_writer_rdma.cc
@@ -6,6 +6,7 @@
 
 #include <stelline/types.hh>
 #include <stelline/operators/filesystem/base.hh>
+#include <fmt/format.h>
 
 #include "utils/helpers.hh"
 #include "utils/modifiers.hh"
@@ -46,10 +47,6 @@ struct Uvh5WriterRdmaOp::Impl {
     std::chrono::time_point<std::chrono::steady_clock> lastMeasurementTime;
     std::atomic<int64_t> bytesSinceLastMeasurement{0};
     std::atomic<double> currentBandwidthMBps{0.0};
-
-    std::thread metricsThread;
-    bool metricsThreadRunning;
-    void metricsLoop();
 };
 
 void Uvh5WriterRdmaOp::initialize() {
@@ -183,23 +180,9 @@ void Uvh5WriterRdmaOp::start() {
     pimpl->bytesSinceLastMeasurement = 0;
     pimpl->lastMeasurementTime = std::chrono::steady_clock::now();
     pimpl->currentBandwidthMBps = 0.0;
-
-    // Start metrics thread.
-
-    pimpl->metricsThreadRunning = true;
-    pimpl->metricsThread = std::thread([&]{
-        pimpl->metricsLoop();
-    });
 }
 
 void Uvh5WriterRdmaOp::stop() {
-    // Stop metrics thread.
-
-    pimpl->metricsThreadRunning = false;
-    if (pimpl->metricsThread.joinable()) {
-        pimpl->metricsThread.join();
-    }
-
     // Close HDF5.
     // replace visdata pointer with something to be freed
     pimpl->uvh5_file.visdata = malloc(8);
@@ -309,23 +292,32 @@ void Uvh5WriterRdmaOp::compute(InputContext& input, OutputContext&, ExecutionCon
     pimpl->bytesSinceLastMeasurement += tensorBytes;
 }
 
-void Uvh5WriterRdmaOp::Impl::metricsLoop() {
-    while (metricsThreadRunning) {
-        auto now = std::chrono::steady_clock::now();
-        auto elapsedSeconds = std::chrono::duration<double>(now - lastMeasurementTime).count();
+stelline::StoreInterface::MetricsMap Uvh5WriterRdmaOp::collectMetricsMap() {
+    auto now = std::chrono::steady_clock::now();
+    auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
-        if (elapsedSeconds > 0.0) {
-            int64_t bytes = bytesSinceLastMeasurement.exchange(0);
-            currentBandwidthMBps = static_cast<double>(bytes) / (1024.0 * 1024.0) / elapsedSeconds;
-            lastMeasurementTime = now;
-        }
-
-        HOLOSCAN_LOG_INFO("HDF5 Sink RDMA Operator:");
-        HOLOSCAN_LOG_INFO("  Current Bandwidth: {:.2f} MB/s", currentBandwidthMBps.load());
-        HOLOSCAN_LOG_INFO("  Total Data Written: {:.0f} MB", static_cast<double>(bytesWritten) / (1024.0 * 1024.0));
-
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+    if (elapsedSeconds > 0.0) {
+        int64_t bytes = pimpl->bytesSinceLastMeasurement.exchange(0);
+        pimpl->currentBandwidthMBps = static_cast<double>(bytes) / (1024.0 * 1024.0) / elapsedSeconds;
+        pimpl->lastMeasurementTime = now;
     }
+
+    stelline::StoreInterface::MetricsMap metrics;
+    metrics["current_bandwidth_mb_s"] = fmt::format("{:.2f}", pimpl->currentBandwidthMBps.load());
+    metrics["total_data_written_mb"] = fmt::format("{:.0f}", static_cast<double>(pimpl->bytesWritten) / (1024.0 * 1024.0));
+    metrics["chunks_written"] = fmt::format("{}", pimpl->chunkCounter);
+    return metrics;
+}
+
+std::string Uvh5WriterRdmaOp::collectMetricsString() {
+    const auto metrics = collectMetricsMap();
+    return fmt::format("HDF5 Sink RDMA Operator:\n"
+                       "  Current Bandwidth: {} MB/s\n"
+                       "  Total Data Written: {} MB\n"
+                       "  Chunks Written: {}",
+                       metrics.at("current_bandwidth_mb_s"),
+                       metrics.at("total_data_written_mb"),
+                       metrics.at("chunks_written"));
 }
 
 }  // namespace stelline::operators::io

--- a/src/operators/frbnn/base.cc
+++ b/src/operators/frbnn/base.cc
@@ -210,6 +210,9 @@ void SimpleDetectionOp::compute(InputContext& input, OutputContext&, ExecutionCo
 }
 
 stelline::StoreInterface::MetricsMap SimpleDetectionOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     stelline::StoreInterface::MetricsMap metrics;
     metrics["iterations"] = fmt::format("{}", pimpl->iterations);
     metrics["hits"] = fmt::format("{}", pimpl->numberOfHits);
@@ -217,9 +220,11 @@ stelline::StoreInterface::MetricsMap SimpleDetectionOp::collectMetricsMap() {
 }
 
 std::string SimpleDetectionOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("Simple Detector Operator:\n"
-                       "  Iterations: {}\n"
+    return fmt::format("  Iterations: {}\n"
                        "  Hits      : {}",
                        metrics.at("iterations"),
                        metrics.at("hits"));

--- a/src/operators/socket/zmq_transmitter.cc
+++ b/src/operators/socket/zmq_transmitter.cc
@@ -120,6 +120,9 @@ void ZmqTransmitterOp::compute(InputContext& input, OutputContext&, ExecutionCon
 }
 
 stelline::StoreInterface::MetricsMap ZmqTransmitterOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     auto now = std::chrono::steady_clock::now();
     auto elapsedSeconds = std::chrono::duration<double>(now - pimpl->lastMeasurementTime).count();
 
@@ -136,9 +139,11 @@ stelline::StoreInterface::MetricsMap ZmqTransmitterOp::collectMetricsMap() {
 }
 
 std::string ZmqTransmitterOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("ZeroMQ Transmitter Operator:\n"
-                       "  Input Bandwidth: {} MB/s\n"
+    return fmt::format("  Input Bandwidth: {} MB/s\n"
                        "  Total Bytes Written: {}",
                        metrics.at("current_bandwidth_mb_s"),
                        metrics.at("total_bytes_written"));

--- a/src/operators/socket/zmq_transmitter.cc
+++ b/src/operators/socket/zmq_transmitter.cc
@@ -43,7 +43,7 @@ ZmqTransmitterOp::~ZmqTransmitterOp() {
 }
 
 void ZmqTransmitterOp::setup(OperatorSpec& spec) {
-    spec.input<DspBlock>("in")
+    spec.input<std::shared_ptr<holoscan::Tensor>>("in")
         .connector(IOSpec::ConnectorType::kDoubleBuffer,
                    holoscan::Arg("capacity", 1024UL));
 
@@ -108,7 +108,7 @@ void ZmqTransmitterOp::stop() {
 }
 
 void ZmqTransmitterOp::compute(InputContext& input, OutputContext&, ExecutionContext&) {
-    const auto& tensor = input.receive<DspBlock>("in").value().tensor;
+    const auto& tensor = input.receive<std::shared_ptr<holoscan::Tensor>>("in").value();
     const auto& tensorBytes = tensor->size() * (tensor->dtype().bits / 8);
 
     // Allocate host bounce buffer.

--- a/src/operators/transport/ata_receiver.cc
+++ b/src/operators/transport/ata_receiver.cc
@@ -430,6 +430,9 @@ void AtaReceiverOp::Impl::burstCollectorLoop() {
 }
 
 stelline::StoreInterface::MetricsMap AtaReceiverOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     std::vector<uint64_t> blockTimes;
     blockTimes.reserve(pimpl->blockMap.size());
     for (const auto& [time, _] : pimpl->blockMap) {
@@ -464,42 +467,43 @@ stelline::StoreInterface::MetricsMap AtaReceiverOp::collectMetricsMap() {
 }
 
 std::string AtaReceiverOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format(
-        "Transport Operator:\n"
-        "  Blocks    : {} received, {} computed, {} lost\n"
-        "  Packets   : {} evicted, {} received, {} lost\n"
-        "  In-Flight : {} idle, {} receive, {} compute\n"
-        "  Bursts    : {} in-flight, {} us average per-burst release time\n"
-        "  Mem Pool  : {} available, {} referenced\n"
-        "  Block Map : latest time index {}, usage {}, all block times {}\n"
-        "  Fine Packet Count:\n"
-        "    Payload Sizes    : {}\n"
-        "    All antennas     : {}\n"
-        "    Filtered antennas: {}\n"
-        "    All channels     : {}\n"
-        "    Filtered channels: {}",
-        metrics.at("blocks_received"),
-        metrics.at("blocks_computed"),
-        metrics.at("blocks_lost"),
-        metrics.at("packets_evicted"),
-        metrics.at("packets_received"),
-        metrics.at("packets_lost"),
-        metrics.at("idle_queue"),
-        metrics.at("receive_queue"),
-        metrics.at("compute_queue"),
-        metrics.at("bursts_in_flight"),
-        metrics.at("avg_burst_release_time_us"),
-        metrics.at("mem_pool_available"),
-        metrics.at("mem_pool_referenced"),
-        metrics.at("block_map_latest_time_index"),
-        metrics.at("block_map_usage"),
-        metrics.at("block_map_times"),
-        metrics.at("payload_sizes"),
-        metrics.at("all_antennas"),
-        metrics.at("filtered_antennas"),
-        metrics.at("all_channels"),
-        metrics.at("filtered_channels"));
+    return fmt::format("  Blocks    : {} received, {} computed, {} lost\n"
+                       "  Packets   : {} evicted, {} received, {} lost\n"
+                       "  In-Flight : {} idle, {} receive, {} compute\n"
+                       "  Bursts    : {} in-flight, {} us average per-burst release time\n"
+                       "  Mem Pool  : {} available, {} referenced\n"
+                       "  Block Map : latest time index {}, usage {}, all block times {}\n"
+                       "  Fine Packet Count:\n"
+                       "    Payload Sizes    : {}\n"
+                       "    All antennas     : {}\n"
+                       "    Filtered antennas: {}\n"
+                       "    All channels     : {}\n"
+                       "    Filtered channels: {}",
+                       metrics.at("blocks_received"),
+                       metrics.at("blocks_computed"),
+                       metrics.at("blocks_lost"),
+                       metrics.at("packets_evicted"),
+                       metrics.at("packets_received"),
+                       metrics.at("packets_lost"),
+                       metrics.at("idle_queue"),
+                       metrics.at("receive_queue"),
+                       metrics.at("compute_queue"),
+                       metrics.at("bursts_in_flight"),
+                       metrics.at("avg_burst_release_time_us"),
+                       metrics.at("mem_pool_available"),
+                       metrics.at("mem_pool_referenced"),
+                       metrics.at("block_map_latest_time_index"),
+                       metrics.at("block_map_usage"),
+                       metrics.at("block_map_times"),
+                       metrics.at("payload_sizes"),
+                       metrics.at("all_antennas"),
+                       metrics.at("filtered_antennas"),
+                       metrics.at("all_channels"),
+                       metrics.at("filtered_channels"));
 }
 
 }  // namespace stelline::operators::transport

--- a/src/operators/transport/block.hh
+++ b/src/operators/transport/block.hh
@@ -43,7 +43,7 @@ struct Block {
         return _timestamp;
     }
 
-    constexpr const std::shared_ptr<Tensor>& outputTensor() const {
+    constexpr const std::shared_ptr<holoscan::Tensor>& outputTensor() const {
         return _outputTensor;
     }
 
@@ -74,7 +74,7 @@ struct Block {
         return cudaStreamQuery(stream) != cudaSuccess;
     }
 
-    inline void compute(std::shared_ptr<Tensor>& outputTensor,
+    inline void compute(std::shared_ptr<holoscan::Tensor>& outputTensor,
                         const BlockShape& total,
                         const BlockShape& partial,
                         const BlockShape& slots) {
@@ -96,7 +96,7 @@ struct Block {
     std::unordered_set<std::shared_ptr<BurstParams>> bursts;
 
     cudaStream_t stream;
-    std::shared_ptr<Tensor> _outputTensor;
+    std::shared_ptr<holoscan::Tensor> _outputTensor;
 };
 
 }  // namespace stelline::operators::transport

--- a/src/operators/transport/sorter.cc
+++ b/src/operators/transport/sorter.cc
@@ -104,6 +104,9 @@ void SorterOp::compute(InputContext& input, OutputContext& output, ExecutionCont
 }
 
 stelline::StoreInterface::MetricsMap SorterOp::collectMetricsMap() {
+    if (!pimpl) {
+        return {};
+    }
     stelline::StoreInterface::MetricsMap metrics;
     metrics["rejected_blocks"] = fmt::format("{}", pimpl->numberOfRejectedBlocks);
     metrics["pool_size"] = fmt::format("{}", pimpl->pool.size());
@@ -111,9 +114,11 @@ stelline::StoreInterface::MetricsMap SorterOp::collectMetricsMap() {
 }
 
 std::string SorterOp::collectMetricsString() {
+    if (!pimpl) {
+        return {};
+    }
     const auto metrics = collectMetricsMap();
-    return fmt::format("Sorter Operator:\n"
-                       "  Number of Rejected Blocks: {}\n"
+    return fmt::format("  Number of Rejected Blocks: {}\n"
                        "  Pool Size: {}",
                        metrics.at("rejected_blocks"),
                        metrics.at("pool_size"));


### PR DESCRIPTION
Stelline v0.2.0 is now available! New features:

- All tensors passed between operators are now holoscan::Tensor instead of a custom data structure.
- Each tensor metadata such as timestamp is now sent using Holoscan's metadata system.
- Operators now report metrics to Stelline using a common data interface StoreInterface.
- This will be updated in v0.3.0 to support metadata coming from Nexus (optional).

All of this enables extending Stelline with custom operators from Python.
This is all the boilerplate you need to tap into the ATA's signal stream from Python:

<img width="889" height="875" alt="Screenshot 2025-11-21 at 4 37 36 PM" src="https://github.com/user-attachments/assets/5dd42999-f278-4520-ad34-4e57353e1d04" />
