### PR TITLE
Add CyberEther reader block supporting FBH5/UVH5 file formats

### DIFF
--- a/examples/fbh5-reader.yml
+++ b/examples/fbh5-reader.yml
@@ -1,0 +1,43 @@
+---
+version: 1.0.0
+
+title: FBH5 Reader
+summary: Offline playback of FBH5 filterbank data into a waterfall.
+graph:
+  fbh5_reader:
+    module: fbh5_reader
+    device: cpu
+    runtime: native
+    provider: generic
+    config:
+      filepath: /tests/test.fbh5
+      batchSize: 256
+      loop: true
+      playing: true
+    meta:
+      node:
+        height: 220
+        width: 260
+        y: 40
+        x: 40
+  waterfall:
+    module: waterfall
+    device: cpu
+    runtime: native
+    provider: generic
+    dataType: F32
+    config:
+      height: 512
+      interpolate: false
+    input:
+      signal: '${graph.fbh5_reader.output.signal}'
+    meta:
+      surface_default:
+        detached: false
+        attachedWidth: 600
+        attachedHeight: 294
+      node:
+        height: 420
+        width: 600
+        y: 40
+        x: 360

--- a/include/stelline/fbh5_reader/block.hh
+++ b/include/stelline/fbh5_reader/block.hh
@@ -1,0 +1,48 @@
+#ifndef STELLINE_FBH5_READER_BLOCK_HH
+#define STELLINE_FBH5_READER_BLOCK_HH
+
+#include <string>
+
+#include <jetstream/block.hh>
+
+namespace Jetstream::Blocks {
+
+struct Fbh5Reader : public Block::Config {
+    std::string filepath = "";
+    U64 batchSize = 256;
+    bool loop = true;
+    bool playing = true;
+
+    JST_BLOCK_TYPE(fbh5_reader);
+    JST_BLOCK_DOMAIN("Stelline");
+    JST_BLOCK_PARAMS(filepath, batchSize, loop, playing);
+    JST_BLOCK_DESCRIPTION(
+        "FBH5 Reader",
+        "Source that reads beamformer filterbank data from an FBH5 file.",
+        "# FBH5 Reader\n"
+        "Reads channelized filterbank data from an FBH5 (HDF5) archive and emits it as "
+        "F32 spectrogram chunks. FBH5 files store data in the dataset `/data` with shape "
+        "[ntimes, nifs, nchans].\n\n"
+
+        "## Arguments\n"
+        "- **File Path**: Path to the `.fbh5` or `.h5` file.\n"
+        "- **Batch Size**: Number of time rows to read per processing cycle.\n"
+        "- **Loop**: Restart from the beginning when the end of file is reached.\n"
+        "- **Playing**: Pause or resume reading.\n\n"
+
+        "## Outputs\n"
+        "- **Signal**: F32 tensor [batchSize, nifs x nchans] — one row per time sample.\n\n"
+
+        "## Useful For\n"
+        "- Offline / archival playback of beamformed spectra into a flowgraph.\n"
+        "- Driving FRBNN inference from recorded FBH5 files.\n\n"
+
+        "## Implementation\n"
+        "Reads with the POSIX HDF5 VFD (no GPUDirect Storage required), so it runs on any "
+        "system that has libhdf5 — including non-NVIDIA hosts."
+    );
+};
+
+}  // namespace Jetstream::Blocks
+
+#endif  // STELLINE_FBH5_READER_BLOCK_HH

--- a/include/stelline/fbh5_reader/module.hh
+++ b/include/stelline/fbh5_reader/module.hh
@@ -1,0 +1,22 @@
+#ifndef STELLINE_FBH5_READER_MODULE_HH
+#define STELLINE_FBH5_READER_MODULE_HH
+
+#include <string>
+
+#include <jetstream/module.hh>
+
+namespace Jetstream::Modules {
+
+struct Fbh5Reader : public Module::Config {
+    std::string filepath = "";
+    U64 batchSize = 256;
+    bool loop = true;
+    bool playing = true;
+
+    JST_MODULE_TYPE(fbh5_reader);
+    JST_MODULE_PARAMS(filepath, batchSize, loop, playing);
+};
+
+}  // namespace Jetstream::Modules
+
+#endif  // STELLINE_FBH5_READER_MODULE_HH

--- a/include/stelline/uvh5_reader/block.hh
+++ b/include/stelline/uvh5_reader/block.hh
@@ -1,0 +1,47 @@
+#ifndef STELLINE_UVH5_READER_BLOCK_HH
+#define STELLINE_UVH5_READER_BLOCK_HH
+
+#include <string>
+
+#include <jetstream/block.hh>
+
+namespace Jetstream::Blocks {
+
+struct Uvh5Reader : public Block::Config {
+    std::string filepath = "";
+    U64 batchSize = 256;
+    bool loop = true;
+    bool playing = true;
+
+    JST_BLOCK_TYPE(uvh5_reader);
+    JST_BLOCK_DOMAIN("Stelline");
+    JST_BLOCK_PARAMS(filepath, batchSize, loop, playing);
+    JST_BLOCK_DESCRIPTION(
+        "UVH5 Reader",
+        "Source that reads correlator visibilities from a UVH5 file.",
+        "# UVH5 Reader\n"
+        "Reads visibility data from a UVH5 (pyuvdata / HDF5) archive and emits it as CF32 "
+        "chunks. UVH5 files store visibilities in `/Data/visdata` with shape "
+        "[Nblts, Nspws, Nfreqs, Npols] complex64.\n\n"
+
+        "## Arguments\n"
+        "- **File Path**: Path to the `.uvh5` or `.h5` file.\n"
+        "- **Batch Size**: Number of baseline-time (blt) entries to read per cycle.\n"
+        "- **Loop**: Restart from the beginning when the end of file is reached.\n"
+        "- **Playing**: Pause or resume reading.\n\n"
+
+        "## Outputs\n"
+        "- **Signal**: CF32 tensor [batchSize, Nspws x Nfreqs, Npols] of visibilities.\n\n"
+
+        "## Useful For\n"
+        "- Offline / archival playback of correlator visibilities into a flowgraph.\n\n"
+
+        "## Implementation\n"
+        "Reads with the POSIX HDF5 VFD (no GPUDirect Storage required), so it runs on any "
+        "system that has libhdf5 — including non-NVIDIA hosts."
+    );
+};
+
+}  // namespace Jetstream::Blocks
+
+#endif  // STELLINE_UVH5_READER_BLOCK_HH

--- a/include/stelline/uvh5_reader/module.hh
+++ b/include/stelline/uvh5_reader/module.hh
@@ -1,0 +1,22 @@
+#ifndef STELLINE_UVH5_READER_MODULE_HH
+#define STELLINE_UVH5_READER_MODULE_HH
+
+#include <string>
+
+#include <jetstream/module.hh>
+
+namespace Jetstream::Modules {
+
+struct Uvh5Reader : public Module::Config {
+    std::string filepath = "";
+    U64 batchSize = 256;
+    bool loop = true;
+    bool playing = true;
+
+    JST_MODULE_TYPE(uvh5_reader);
+    JST_MODULE_PARAMS(filepath, batchSize, loop, playing);
+};
+
+}  // namespace Jetstream::Modules
+
+#endif  // STELLINE_UVH5_READER_MODULE_HH

--- a/src/fs/fbh5_reader/block_impl.cc
+++ b/src/fs/fbh5_reader/block_impl.cc
@@ -1,0 +1,110 @@
+#include <stelline/fbh5_reader/block.hh>
+#include <jetstream/detail/block_impl.hh>
+#include <stelline/fbh5_reader/module.hh>
+
+#include "module_impl.hh"
+
+namespace Jetstream::Blocks {
+
+struct Fbh5ReaderImpl : public Block::Impl, public DynamicConfig<Blocks::Fbh5Reader> {
+    Result configure() override;
+    Result define() override;
+    Result create() override;
+
+ protected:
+    std::shared_ptr<Modules::Fbh5Reader> moduleConfig = std::make_shared<Modules::Fbh5Reader>();
+    Modules::Fbh5ReaderImpl* moduleImpl = nullptr;
+};
+
+Result Fbh5ReaderImpl::configure() {
+    moduleConfig->filepath = filepath;
+    moduleConfig->batchSize = batchSize;
+    moduleConfig->loop = loop;
+    moduleConfig->playing = playing;
+
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::define() {
+    JST_CHECK(defineInterfaceOutput("signal",
+                                    "Output",
+                                    "F32 tensor [batchSize, nifs x nchans] of filterbank samples."));
+
+    JST_CHECK(defineInterfaceConfig("filepath",
+                                    "File Path",
+                                    "Path to the FBH5 (HDF5) beamformer filterbank file.",
+                                    "filepicker:fbh5,h5,hdf5"));
+
+    JST_CHECK(defineInterfaceConfig("batchSize",
+                                    "Batch Size",
+                                    "Number of time rows to read per processing cycle.",
+                                    "int:samples"));
+
+    JST_CHECK(defineInterfaceConfig("loop",
+                                    "Loop",
+                                    "Restart from the beginning when reaching the end of the file.",
+                                    "bool"));
+
+    JST_CHECK(defineInterfaceConfig("playing",
+                                    "Playing",
+                                    "Pause or resume reading.",
+                                    "bool"));
+
+    JST_CHECK(defineInterfaceMetric("progress",
+                                    "Position",
+                                    "Current position in the file.",
+                                    "progressbar",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::pair<std::string, F32>{"0.0%", 0.0f};
+            }
+            const U64 total = moduleImpl->getTotalRows();
+            if (total == 0) {
+                return std::pair<std::string, F32>{"0.0%", 0.0f};
+            }
+            const F32 progress = static_cast<F32>(moduleImpl->getCurrentRow()) /
+                                 static_cast<F32>(total);
+            return std::pair<std::string, F32>{jst::fmt::format("{:.1f}%", progress * 100.0f), progress};
+        }));
+
+    JST_CHECK(defineInterfaceMetric("currentBandwidth",
+                                    "Bandwidth",
+                                    "Smoothed HDF5 read throughput.",
+                                    "label",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::string("N/A");
+            }
+            return jst::fmt::format("{:.1f} MB/s", moduleImpl->getCurrentBandwidth());
+        }));
+
+    JST_CHECK(defineInterfaceMetric("fileInfo",
+                                    "File Info",
+                                    "Number of time rows in the opened dataset.",
+                                    "label",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::string("-");
+            }
+            const U64 total = moduleImpl->getTotalRows();
+            if (total == 0) {
+                return std::string("-");
+            }
+            return jst::fmt::format("{} rows", total);
+        }));
+
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::create() {
+    JST_CHECK(moduleCreate("fbh5_reader", moduleConfig, {}));
+    JST_CHECK(moduleExposeOutput("signal", {"fbh5_reader", "signal"}));
+
+    moduleImpl = moduleHandle("fbh5_reader")->getImpl<Modules::Fbh5ReaderImpl>();
+
+    return Result::SUCCESS;
+}
+
+JST_REGISTER_BLOCK(Fbh5ReaderImpl);
+
+}  // namespace Jetstream::Blocks

--- a/src/fs/fbh5_reader/meson.build
+++ b/src/fs/fbh5_reader/meson.build
@@ -1,0 +1,5 @@
+src_lst += files([
+    'block_impl.cc',
+    'module_impl.cc',
+    'module_impl_native_cpu.cc',
+])

--- a/src/fs/fbh5_reader/module_impl.cc
+++ b/src/fs/fbh5_reader/module_impl.cc
@@ -1,0 +1,151 @@
+#include "module_impl.hh"
+
+namespace Jetstream::Modules {
+
+Result Fbh5ReaderImpl::validate() {
+    const auto& config = *candidate();
+
+    if (config.batchSize == 0) {
+        JST_ERROR("[MODULE_FBH5_READER] Batch size cannot be zero.");
+        return Result::ERROR;
+    }
+
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::define() {
+    JST_CHECK(defineInterfaceOutput("signal"));
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::create() {
+    snapshotTotalRows.publish(0);
+    snapshotCurrentRow.publish(0);
+    snapshotBandwidth.publish(0.0f);
+    bytesSinceLastMeasurement = 0;
+    lastMeasurementTime = std::chrono::steady_clock::now();
+
+    if (filepath.empty()) {
+        JST_WARN("[MODULE_FBH5_READER] File path is empty.");
+        return Result::INCOMPLETE;
+    }
+
+    // Suppress the default HDF5 error stack printing; we handle errors ourselves.
+    H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
+
+    // Open the file read-only with the default (POSIX) VFD — no GDS required.
+    fileId = H5Fopen(filepath.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    if (fileId < 0) {
+        JST_WARN("[MODULE_FBH5_READER] Cannot open HDF5 file '{}'.", filepath);
+        return Result::INCOMPLETE;
+    }
+
+    datasetId = H5Dopen2(fileId, "/data", H5P_DEFAULT);
+    if (datasetId < 0) {
+        H5Fclose(fileId);
+        fileId = H5I_INVALID_HID;
+        JST_WARN("[MODULE_FBH5_READER] Dataset '/data' not found in '{}'.", filepath);
+        return Result::INCOMPLETE;
+    }
+
+    dataspaceId = H5Dget_space(datasetId);
+    if (dataspaceId < 0) {
+        H5Dclose(datasetId);
+        H5Fclose(fileId);
+        datasetId = H5I_INVALID_HID;
+        fileId = H5I_INVALID_HID;
+        JST_ERROR("[MODULE_FBH5_READER] Failed to get dataspace for '/data'.");
+        return Result::ERROR;
+    }
+
+    const int ndims = H5Sget_simple_extent_ndims(dataspaceId);
+    if (ndims != 3) {
+        H5Sclose(dataspaceId);
+        H5Dclose(datasetId);
+        H5Fclose(fileId);
+        dataspaceId = H5I_INVALID_HID;
+        datasetId = H5I_INVALID_HID;
+        fileId = H5I_INVALID_HID;
+        JST_ERROR("[MODULE_FBH5_READER] Expected 3-D dataset [ntimes, nifs, nchans], got {}.", ndims);
+        return Result::ERROR;
+    }
+
+    hsize_t dims[3];
+    H5Sget_simple_extent_dims(dataspaceId, dims, nullptr);
+    dimNtimes = dims[0];
+    dimNifs = dims[1];
+    dimNchans = dims[2];
+
+    currentRow = 0;
+    snapshotTotalRows.publish(static_cast<U64>(dimNtimes));
+    snapshotCurrentRow.publish(0);
+
+    const U64 numChannels = static_cast<U64>(dimNifs) * static_cast<U64>(dimNchans);
+    JST_CHECK(buffer.create(device(), DataType::F32, {batchSize, numChannels}));
+    outputs()["signal"].produced(name(), "signal", buffer);
+
+    JST_INFO("[MODULE_FBH5_READER] Opened '{}': ntimes={} nifs={} nchans={}.",
+             filepath, dimNtimes, dimNifs, dimNchans);
+
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::destroy() {
+    if (dataspaceId >= 0) { H5Sclose(dataspaceId); dataspaceId = H5I_INVALID_HID; }
+    if (datasetId >= 0)   { H5Dclose(datasetId);   datasetId = H5I_INVALID_HID; }
+    if (fileId >= 0)      { H5Fclose(fileId);      fileId = H5I_INVALID_HID; }
+
+    snapshotBandwidth.publish(0.0f);
+    bytesSinceLastMeasurement = 0;
+
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImpl::reconfigure() {
+    const auto& config = *candidate();
+
+    if (config.filepath != filepath ||
+        config.batchSize != batchSize) {
+        return Result::RECREATE;
+    }
+
+    loop = config.loop;
+    playing = config.playing;
+    return Result::SUCCESS;
+}
+
+U64 Fbh5ReaderImpl::getCurrentRow() const {
+    return snapshotCurrentRow.get();
+}
+
+U64 Fbh5ReaderImpl::getTotalRows() const {
+    return snapshotTotalRows.get();
+}
+
+F32 Fbh5ReaderImpl::getCurrentBandwidth() const {
+    return snapshotBandwidth.get();
+}
+
+void Fbh5ReaderImpl::updateBandwidth(const U64 deltaBytes) {
+    constexpr double kPeriodSeconds = 0.10;
+    constexpr double kEmaAlpha = 0.3;
+
+    bytesSinceLastMeasurement += deltaBytes;
+
+    const auto now = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(now - lastMeasurementTime).count();
+    if (elapsed < kPeriodSeconds) {
+        return;
+    }
+
+    const double instant = static_cast<double>(bytesSinceLastMeasurement) /
+                           (1024.0 * 1024.0) / elapsed;
+    const double smoothed = kEmaAlpha * instant +
+                            (1.0 - kEmaAlpha) * snapshotBandwidth.get();
+    snapshotBandwidth.publish(static_cast<F32>(smoothed));
+
+    bytesSinceLastMeasurement = 0;
+    lastMeasurementTime = now;
+}
+
+}  // namespace Jetstream::Modules

--- a/src/fs/fbh5_reader/module_impl.hh
+++ b/src/fs/fbh5_reader/module_impl.hh
@@ -1,0 +1,52 @@
+#ifndef STELLINE_FBH5_READER_MODULE_IMPL_HH
+#define STELLINE_FBH5_READER_MODULE_IMPL_HH
+
+#include <chrono>
+
+#include <hdf5.h>
+
+#include <stelline/fbh5_reader/module.hh>
+#include <jetstream/detail/module_impl.hh>
+#include <jetstream/tools/snapshot.hh>
+
+namespace Jetstream::Modules {
+
+struct Fbh5ReaderImpl : public Module::Impl, public DynamicConfig<Fbh5Reader> {
+ public:
+    Result validate() override;
+    Result define() override;
+    Result create() override;
+    Result destroy() override;
+    Result reconfigure() override;
+
+    U64 getCurrentRow() const;
+    U64 getTotalRows() const;
+    F32 getCurrentBandwidth() const;
+
+ protected:
+    void updateBandwidth(const U64 deltaBytes);
+
+    Tensor buffer;
+
+    hid_t fileId = H5I_INVALID_HID;
+    hid_t datasetId = H5I_INVALID_HID;
+    hid_t dataspaceId = H5I_INVALID_HID;
+
+    // Dataset dims: [ntimes, nifs, nchans].
+    hsize_t dimNtimes = 0;
+    hsize_t dimNifs = 0;
+    hsize_t dimNchans = 0;
+
+    U64 currentRow = 0;
+
+    U64 bytesSinceLastMeasurement = 0;
+    std::chrono::steady_clock::time_point lastMeasurementTime{};
+
+    Tools::Snapshot<U64> snapshotTotalRows{0};
+    Tools::Snapshot<U64> snapshotCurrentRow{0};
+    Tools::Snapshot<F32> snapshotBandwidth{0.0f};
+};
+
+}  // namespace Jetstream::Modules
+
+#endif  // STELLINE_FBH5_READER_MODULE_IMPL_HH

--- a/src/fs/fbh5_reader/module_impl_native_cpu.cc
+++ b/src/fs/fbh5_reader/module_impl_native_cpu.cc
@@ -1,0 +1,86 @@
+#include <algorithm>
+
+#include <jetstream/runtime_context_native_cpu.hh>
+#include <jetstream/scheduler_context.hh>
+#include <jetstream/module_context.hh>
+#include <jetstream/registry.hh>
+
+#include "module_impl.hh"
+
+namespace Jetstream::Modules {
+
+struct Fbh5ReaderImplNativeCpu : public Fbh5ReaderImpl,
+                                 public NativeCpuRuntimeContext,
+                                 public Scheduler::Context {
+ public:
+    Result create() final;
+    Result computeSubmit() override;
+};
+
+Result Fbh5ReaderImplNativeCpu::create() {
+    JST_CHECK(Fbh5ReaderImpl::create());
+    return Result::SUCCESS;
+}
+
+Result Fbh5ReaderImplNativeCpu::computeSubmit() {
+    if (fileId < 0 || !playing) {
+        return Result::SUCCESS;
+    }
+
+    const U64 numChannels = static_cast<U64>(dimNifs) * static_cast<U64>(dimNchans);
+    const U64 totalRows = static_cast<U64>(dimNtimes);
+
+    U64 rowsRemaining = totalRows - currentRow;
+    if (rowsRemaining == 0) {
+        if (loop) {
+            currentRow = 0;
+            rowsRemaining = totalRows;
+        } else {
+            return Result::SUCCESS;
+        }
+    }
+
+    const U64 rowsToRead = std::min(static_cast<U64>(batchSize), rowsRemaining);
+
+    // Select hyperslab: [currentRow, 0, 0] -> [rowsToRead, dimNifs, dimNchans].
+    const hsize_t start[3] = {static_cast<hsize_t>(currentRow), 0, 0};
+    const hsize_t count[3] = {static_cast<hsize_t>(rowsToRead),
+                              static_cast<hsize_t>(dimNifs),
+                              static_cast<hsize_t>(dimNchans)};
+
+    if (H5Sselect_hyperslab(dataspaceId, H5S_SELECT_SET,
+                            start, nullptr, count, nullptr) < 0) {
+        JST_ERROR("[MODULE_FBH5_READER] H5Sselect_hyperslab failed.");
+        return Result::ERROR;
+    }
+
+    // Memory dataspace: flat [rowsToRead * numChannels].
+    const hsize_t memDims[1] = {static_cast<hsize_t>(rowsToRead * numChannels)};
+    hid_t memspace = H5Screate_simple(1, memDims, nullptr);
+    if (memspace < 0) {
+        JST_ERROR("[MODULE_FBH5_READER] H5Screate_simple failed.");
+        return Result::ERROR;
+    }
+
+    herr_t status = H5Dread(datasetId, H5T_NATIVE_FLOAT, memspace,
+                            dataspaceId, H5P_DEFAULT,
+                            buffer.data<F32>());
+    H5Sclose(memspace);
+
+    if (status < 0) {
+        JST_ERROR("[MODULE_FBH5_READER] H5Dread failed at row {}.", currentRow);
+        return Result::ERROR;
+    }
+
+    currentRow += rowsToRead;
+    snapshotCurrentRow.publish(currentRow);
+
+    const U64 bytesRead = rowsToRead * numChannels * sizeof(F32);
+    updateBandwidth(bytesRead);
+
+    return Result::SUCCESS;
+}
+
+JST_REGISTER_MODULE(Fbh5ReaderImplNativeCpu, DeviceType::CPU, RuntimeType::NATIVE, "generic");
+
+}  // namespace Jetstream::Modules

--- a/src/fs/meson.build
+++ b/src/fs/meson.build
@@ -1,2 +1,4 @@
+subdir('fbh5_reader')
 subdir('fbh5_writer')
+subdir('uvh5_reader')
 subdir('uvh5_writer')

--- a/src/fs/uvh5_reader/block_impl.cc
+++ b/src/fs/uvh5_reader/block_impl.cc
@@ -1,0 +1,110 @@
+#include <stelline/uvh5_reader/block.hh>
+#include <jetstream/detail/block_impl.hh>
+#include <stelline/uvh5_reader/module.hh>
+
+#include "module_impl.hh"
+
+namespace Jetstream::Blocks {
+
+struct Uvh5ReaderImpl : public Block::Impl, public DynamicConfig<Blocks::Uvh5Reader> {
+    Result configure() override;
+    Result define() override;
+    Result create() override;
+
+ protected:
+    std::shared_ptr<Modules::Uvh5Reader> moduleConfig = std::make_shared<Modules::Uvh5Reader>();
+    Modules::Uvh5ReaderImpl* moduleImpl = nullptr;
+};
+
+Result Uvh5ReaderImpl::configure() {
+    moduleConfig->filepath = filepath;
+    moduleConfig->batchSize = batchSize;
+    moduleConfig->loop = loop;
+    moduleConfig->playing = playing;
+
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::define() {
+    JST_CHECK(defineInterfaceOutput("signal",
+                                    "Output",
+                                    "CF32 tensor [batchSize, Nspws x Nfreqs, Npols] of visibilities."));
+
+    JST_CHECK(defineInterfaceConfig("filepath",
+                                    "File Path",
+                                    "Path to the UVH5 (HDF5) correlator visibility file.",
+                                    "filepicker:uvh5,h5,hdf5"));
+
+    JST_CHECK(defineInterfaceConfig("batchSize",
+                                    "Batch Size",
+                                    "Number of baseline-time (blt) entries to read per cycle.",
+                                    "int:samples"));
+
+    JST_CHECK(defineInterfaceConfig("loop",
+                                    "Loop",
+                                    "Restart from the beginning when reaching the end of the file.",
+                                    "bool"));
+
+    JST_CHECK(defineInterfaceConfig("playing",
+                                    "Playing",
+                                    "Pause or resume reading.",
+                                    "bool"));
+
+    JST_CHECK(defineInterfaceMetric("progress",
+                                    "Position",
+                                    "Current position in the file.",
+                                    "progressbar",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::pair<std::string, F32>{"0.0%", 0.0f};
+            }
+            const U64 total = moduleImpl->getTotalBlts();
+            if (total == 0) {
+                return std::pair<std::string, F32>{"0.0%", 0.0f};
+            }
+            const F32 progress = static_cast<F32>(moduleImpl->getCurrentBlt()) /
+                                 static_cast<F32>(total);
+            return std::pair<std::string, F32>{jst::fmt::format("{:.1f}%", progress * 100.0f), progress};
+        }));
+
+    JST_CHECK(defineInterfaceMetric("currentBandwidth",
+                                    "Bandwidth",
+                                    "Smoothed HDF5 read throughput.",
+                                    "label",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::string("N/A");
+            }
+            return jst::fmt::format("{:.1f} MB/s", moduleImpl->getCurrentBandwidth());
+        }));
+
+    JST_CHECK(defineInterfaceMetric("fileInfo",
+                                    "File Info",
+                                    "Number of baseline-time entries in the opened dataset.",
+                                    "label",
+        [this]() -> std::any {
+            if (!moduleImpl) {
+                return std::string("-");
+            }
+            const U64 total = moduleImpl->getTotalBlts();
+            if (total == 0) {
+                return std::string("-");
+            }
+            return jst::fmt::format("{} blts", total);
+        }));
+
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::create() {
+    JST_CHECK(moduleCreate("uvh5_reader", moduleConfig, {}));
+    JST_CHECK(moduleExposeOutput("signal", {"uvh5_reader", "signal"}));
+
+    moduleImpl = moduleHandle("uvh5_reader")->getImpl<Modules::Uvh5ReaderImpl>();
+
+    return Result::SUCCESS;
+}
+
+JST_REGISTER_BLOCK(Uvh5ReaderImpl);
+
+}  // namespace Jetstream::Blocks

--- a/src/fs/uvh5_reader/meson.build
+++ b/src/fs/uvh5_reader/meson.build
@@ -1,0 +1,5 @@
+src_lst += files([
+    'block_impl.cc',
+    'module_impl.cc',
+    'module_impl_native_cpu.cc',
+])

--- a/src/fs/uvh5_reader/module_impl.cc
+++ b/src/fs/uvh5_reader/module_impl.cc
@@ -1,0 +1,157 @@
+#include "module_impl.hh"
+
+namespace Jetstream::Modules {
+
+// UVH5 HDF5 group / dataset paths (pyuvdata / UVH5 specification).
+static constexpr const char* kUvh5VisdataDataset = "/Data/visdata";
+
+Result Uvh5ReaderImpl::validate() {
+    const auto& config = *candidate();
+
+    if (config.batchSize == 0) {
+        JST_ERROR("[MODULE_UVH5_READER] Batch size cannot be zero.");
+        return Result::ERROR;
+    }
+
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::define() {
+    JST_CHECK(defineInterfaceOutput("signal"));
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::create() {
+    snapshotTotalBlts.publish(0);
+    snapshotCurrentBlt.publish(0);
+    snapshotBandwidth.publish(0.0f);
+    bytesSinceLastMeasurement = 0;
+    lastMeasurementTime = std::chrono::steady_clock::now();
+
+    if (filepath.empty()) {
+        JST_WARN("[MODULE_UVH5_READER] File path is empty.");
+        return Result::INCOMPLETE;
+    }
+
+    // Suppress the default HDF5 error stack printing; we handle errors ourselves.
+    H5Eset_auto(H5E_DEFAULT, nullptr, nullptr);
+
+    // Open the file read-only with the default (POSIX) VFD — no GDS required.
+    fileId = H5Fopen(filepath.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+    if (fileId < 0) {
+        JST_WARN("[MODULE_UVH5_READER] Cannot open HDF5 file '{}'.", filepath);
+        return Result::INCOMPLETE;
+    }
+
+    visDatasetId = H5Dopen2(fileId, kUvh5VisdataDataset, H5P_DEFAULT);
+    if (visDatasetId < 0) {
+        H5Fclose(fileId);
+        fileId = H5I_INVALID_HID;
+        JST_WARN("[MODULE_UVH5_READER] Dataset '{}' not found in '{}'.", kUvh5VisdataDataset, filepath);
+        return Result::INCOMPLETE;
+    }
+
+    visDataspaceId = H5Dget_space(visDatasetId);
+    if (visDataspaceId < 0) {
+        H5Dclose(visDatasetId);
+        H5Fclose(fileId);
+        visDatasetId = H5I_INVALID_HID;
+        fileId = H5I_INVALID_HID;
+        JST_ERROR("[MODULE_UVH5_READER] Failed to get dataspace for '{}'.", kUvh5VisdataDataset);
+        return Result::ERROR;
+    }
+
+    const int ndims = H5Sget_simple_extent_ndims(visDataspaceId);
+    if (ndims != 4) {
+        H5Sclose(visDataspaceId);
+        H5Dclose(visDatasetId);
+        H5Fclose(fileId);
+        visDataspaceId = H5I_INVALID_HID;
+        visDatasetId = H5I_INVALID_HID;
+        fileId = H5I_INVALID_HID;
+        JST_ERROR("[MODULE_UVH5_READER] Expected 4-D visdata [Nblts, Nspws, Nfreqs, Npols], got {}.", ndims);
+        return Result::ERROR;
+    }
+
+    hsize_t dims[4];
+    H5Sget_simple_extent_dims(visDataspaceId, dims, nullptr);
+    dimNblts = dims[0];
+    dimNspws = dims[1];
+    dimNfreqs = dims[2];
+    dimNpols = dims[3];
+
+    currentBlt = 0;
+    snapshotTotalBlts.publish(static_cast<U64>(dimNblts));
+    snapshotCurrentBlt.publish(0);
+
+    // Flatten the (usually singleton) Nspws axis into Nfreqs for the output tensor.
+    const U64 numChannels = static_cast<U64>(dimNspws) * static_cast<U64>(dimNfreqs);
+    const U64 numPols = static_cast<U64>(dimNpols);
+    JST_CHECK(buffer.create(device(), DataType::CF32, {batchSize, numChannels, numPols}));
+    outputs()["signal"].produced(name(), "signal", buffer);
+
+    JST_INFO("[MODULE_UVH5_READER] Opened '{}': Nblts={} Nspws={} Nfreqs={} Npols={}.",
+             filepath, dimNblts, dimNspws, dimNfreqs, dimNpols);
+
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::destroy() {
+    if (visDataspaceId >= 0) { H5Sclose(visDataspaceId); visDataspaceId = H5I_INVALID_HID; }
+    if (visDatasetId >= 0)   { H5Dclose(visDatasetId);   visDatasetId = H5I_INVALID_HID; }
+    if (fileId >= 0)         { H5Fclose(fileId);         fileId = H5I_INVALID_HID; }
+
+    snapshotBandwidth.publish(0.0f);
+    bytesSinceLastMeasurement = 0;
+
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImpl::reconfigure() {
+    const auto& config = *candidate();
+
+    if (config.filepath != filepath ||
+        config.batchSize != batchSize) {
+        return Result::RECREATE;
+    }
+
+    loop = config.loop;
+    playing = config.playing;
+    return Result::SUCCESS;
+}
+
+U64 Uvh5ReaderImpl::getCurrentBlt() const {
+    return snapshotCurrentBlt.get();
+}
+
+U64 Uvh5ReaderImpl::getTotalBlts() const {
+    return snapshotTotalBlts.get();
+}
+
+F32 Uvh5ReaderImpl::getCurrentBandwidth() const {
+    return snapshotBandwidth.get();
+}
+
+void Uvh5ReaderImpl::updateBandwidth(const U64 deltaBytes) {
+    constexpr double kPeriodSeconds = 0.10;
+    constexpr double kEmaAlpha = 0.3;
+
+    bytesSinceLastMeasurement += deltaBytes;
+
+    const auto now = std::chrono::steady_clock::now();
+    const double elapsed = std::chrono::duration<double>(now - lastMeasurementTime).count();
+    if (elapsed < kPeriodSeconds) {
+        return;
+    }
+
+    const double instant = static_cast<double>(bytesSinceLastMeasurement) /
+                           (1024.0 * 1024.0) / elapsed;
+    const double smoothed = kEmaAlpha * instant +
+                            (1.0 - kEmaAlpha) * snapshotBandwidth.get();
+    snapshotBandwidth.publish(static_cast<F32>(smoothed));
+
+    bytesSinceLastMeasurement = 0;
+    lastMeasurementTime = now;
+}
+
+}  // namespace Jetstream::Modules

--- a/src/fs/uvh5_reader/module_impl.hh
+++ b/src/fs/uvh5_reader/module_impl.hh
@@ -1,0 +1,53 @@
+#ifndef STELLINE_UVH5_READER_MODULE_IMPL_HH
+#define STELLINE_UVH5_READER_MODULE_IMPL_HH
+
+#include <chrono>
+
+#include <hdf5.h>
+
+#include <stelline/uvh5_reader/module.hh>
+#include <jetstream/detail/module_impl.hh>
+#include <jetstream/tools/snapshot.hh>
+
+namespace Jetstream::Modules {
+
+struct Uvh5ReaderImpl : public Module::Impl, public DynamicConfig<Uvh5Reader> {
+ public:
+    Result validate() override;
+    Result define() override;
+    Result create() override;
+    Result destroy() override;
+    Result reconfigure() override;
+
+    U64 getCurrentBlt() const;
+    U64 getTotalBlts() const;
+    F32 getCurrentBandwidth() const;
+
+ protected:
+    void updateBandwidth(const U64 deltaBytes);
+
+    Tensor buffer;
+
+    hid_t fileId = H5I_INVALID_HID;
+    hid_t visDatasetId = H5I_INVALID_HID;
+    hid_t visDataspaceId = H5I_INVALID_HID;
+
+    // visdata dims: [Nblts, Nspws, Nfreqs, Npols] complex64.
+    hsize_t dimNblts = 0;
+    hsize_t dimNspws = 0;
+    hsize_t dimNfreqs = 0;
+    hsize_t dimNpols = 0;
+
+    U64 currentBlt = 0;
+
+    U64 bytesSinceLastMeasurement = 0;
+    std::chrono::steady_clock::time_point lastMeasurementTime{};
+
+    Tools::Snapshot<U64> snapshotTotalBlts{0};
+    Tools::Snapshot<U64> snapshotCurrentBlt{0};
+    Tools::Snapshot<F32> snapshotBandwidth{0.0f};
+};
+
+}  // namespace Jetstream::Modules
+
+#endif  // STELLINE_UVH5_READER_MODULE_IMPL_HH

--- a/src/fs/uvh5_reader/module_impl_native_cpu.cc
+++ b/src/fs/uvh5_reader/module_impl_native_cpu.cc
@@ -1,0 +1,93 @@
+#include <algorithm>
+#include <complex>
+
+#include <jetstream/runtime_context_native_cpu.hh>
+#include <jetstream/scheduler_context.hh>
+#include <jetstream/module_context.hh>
+#include <jetstream/registry.hh>
+
+#include "module_impl.hh"
+
+namespace Jetstream::Modules {
+
+struct Uvh5ReaderImplNativeCpu : public Uvh5ReaderImpl,
+                                 public NativeCpuRuntimeContext,
+                                 public Scheduler::Context {
+ public:
+    Result create() final;
+    Result computeSubmit() override;
+};
+
+Result Uvh5ReaderImplNativeCpu::create() {
+    JST_CHECK(Uvh5ReaderImpl::create());
+    return Result::SUCCESS;
+}
+
+Result Uvh5ReaderImplNativeCpu::computeSubmit() {
+    if (fileId < 0 || !playing) {
+        return Result::SUCCESS;
+    }
+
+    const U64 totalBlts = static_cast<U64>(dimNblts);
+
+    U64 bltsRemaining = totalBlts - currentBlt;
+    if (bltsRemaining == 0) {
+        if (loop) {
+            currentBlt = 0;
+            bltsRemaining = totalBlts;
+        } else {
+            return Result::SUCCESS;
+        }
+    }
+
+    const U64 bltsToRead = std::min(static_cast<U64>(batchSize), bltsRemaining);
+
+    // Select hyperslab: [currentBlt, 0, 0, 0] -> [bltsToRead, Nspws, Nfreqs, Npols].
+    const hsize_t start[4] = {static_cast<hsize_t>(currentBlt), 0, 0, 0};
+    const hsize_t count[4] = {static_cast<hsize_t>(bltsToRead),
+                              static_cast<hsize_t>(dimNspws),
+                              static_cast<hsize_t>(dimNfreqs),
+                              static_cast<hsize_t>(dimNpols)};
+
+    if (H5Sselect_hyperslab(visDataspaceId, H5S_SELECT_SET,
+                            start, nullptr, count, nullptr) < 0) {
+        JST_ERROR("[MODULE_UVH5_READER] H5Sselect_hyperslab failed.");
+        return Result::ERROR;
+    }
+
+    // HDF5 complex64 compound type matching std::complex<float> layout {r, i}.
+    hid_t complexType = H5Tcreate(H5T_COMPOUND, sizeof(std::complex<float>));
+    H5Tinsert(complexType, "r", 0, H5T_NATIVE_FLOAT);
+    H5Tinsert(complexType, "i", sizeof(float), H5T_NATIVE_FLOAT);
+
+    hid_t memspace = H5Screate_simple(4, count, nullptr);
+    if (memspace < 0) {
+        H5Tclose(complexType);
+        JST_ERROR("[MODULE_UVH5_READER] H5Screate_simple failed.");
+        return Result::ERROR;
+    }
+
+    herr_t status = H5Dread(visDatasetId, complexType, memspace,
+                            visDataspaceId, H5P_DEFAULT,
+                            buffer.data<CF32>());
+    H5Sclose(memspace);
+    H5Tclose(complexType);
+
+    if (status < 0) {
+        JST_ERROR("[MODULE_UVH5_READER] H5Dread (visdata) failed at blt {}.", currentBlt);
+        return Result::ERROR;
+    }
+
+    currentBlt += bltsToRead;
+    snapshotCurrentBlt.publish(currentBlt);
+
+    const U64 bytesRead = bltsToRead * static_cast<U64>(dimNspws) * static_cast<U64>(dimNfreqs) *
+                          static_cast<U64>(dimNpols) * sizeof(std::complex<float>);
+    updateBandwidth(bytesRead);
+
+    return Result::SUCCESS;
+}
+
+JST_REGISTER_MODULE(Uvh5ReaderImplNativeCpu, DeviceType::CPU, RuntimeType::NATIVE, "generic");
+
+}  // namespace Jetstream::Modules


### PR DESCRIPTION
## Description
Add FBH5 and UVH5 reader blocks in the CyberEther plugin (Block/Module) architecture, mirroring the existing fbh5_writer/uvh5_writer blocks.

- fbh5_reader: reads /data [ntimes, nifs, nchans] and emits F32 [batchSize, nifs*nchans].
- uvh5_reader: reads /Data/visdata [Nblts, Nspws, Nfreqs, Npols] complex64 and emits CF32 [batchSize, Nspws*Nfreqs, Npols].

Both are CPU-native modules (`DeviceType::CPU, RuntimeType::NATIVE`) using the `POSIX HDF5 VFD` (no `GPUDirect Storage`), so they run on `non-NVIDIA` hosts. Provides loop/playing controls, progress/bandwidth/file-info metrics, and a config UI consistent with the writer blocks. Adds `examples/fbh5-reader.yml` (reader -> waterfall) smoke flowgraph.

## Testing

The FBH5/UVH5 reader blocks were validated at three levels.

### 1. Build
  `meson setup` resolves all wraps (cyberether, hdf5, filterbankc99, uvh5c99, vfd-gds) and both readers' translation units compile cleanly against the CyberEther/Jetstream API.

### 2. Data correctness (vs h5py oracle)
  A standalone harness replicating each reader's exact HDF5 read path (open -> per-cycle hyperslab -> read -> batch advance -> loop-wrap) was run on deterministic files and compared byte-for-byte to h5py:
  - **FBH5** `/data` f32 `[32768,1,192]`: MATCH for `batchSize=1000/40 reads` (768-row partial + wrap) and `256/256` (2 passes). Layout `[batchSize, nifs*nchans]` confirmed.
  - **UVH5** `/Data/visdata` complex64 `[500,1,64,4]`: bit-identical for `128/10` (116-blt partial + wrap) and `100/12`. Compound `{r,i}` read + `[batchSize, Nspws*Nfreqs, Npols]` layout confirmed.

### 3. Headless runtime (CyberEther)
  Packaged as a `.cep` and loaded into `cyberether run --headless`:
  - Both blocks register: `[REGISTRY] Registering block [Type: fbh5_reader, Domain: Stelline]` and `... uvh5_reader ...` (Runtime: Native, Device: CPU).
  - `fbh5_reader` instantiates, opens the file, and reports the correct shape: `[MODULE_FBH5_READER] Opened '.../test.fbh5': ntimes=32768 nifs=1 nchans=192`, then exposes its `signal` output and the synchronous scheduler runs its compute loop until interrupted.

_(**note:** I accidentally closed #10 and re-opened this one, cleaner)_