### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "name": "Stelline",
+  "user": "root",
+  "image": "ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-x86_64-cuda",
+  "install": "apt-get update --fix-missing && apt-get install -y --no-install-recommends cmake libdpdk-dev && rm -rf /var/lib/apt/lists/* && git config --global --add safe.directory '*' && rm -rf build && meson setup build -Dbuildtype=release -Ddevices=cuda && meson compile -C build stelline_cep"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent environment (`.cursor/environment.json`) so Stelline is fully buildable in Cursor Cloud Agents out of the box.

The configuration mirrors the project's CI build ([`.github/workflows/cep.yml`](.github/workflows/cep.yml)) exactly:

- **Base image**: `ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-x86_64-cuda` — the same prebuilt CyberEther CUDA image CI uses. It bundles the CUDA toolkit (13.0), Meson/Ninja, and Jetstream/CyberEther `1.8.2` (discoverable via `pkg-config`), which lets Meson resolve the `jetstream` dependency as a system package instead of building the large CyberEther subproject from source.
- **`install`**: installs the two missing host packages (`cmake`, `libdpdk-dev`), then runs `meson setup build -Dbuildtype=release -Ddevices=cuda` and `meson compile -C build stelline_cep`. This fetches all Meson wrap subprojects (erfa, hdf5, uvh5c99, daqiri, catch2, …) and produces the loadable plugin bundle `build/stelline.cep`. The command is idempotent (`rm -rf build` before configuring).

Note: the ATA Receiver / writer blocks require real GPU, RDMA NIC, and GPUDirect Storage hardware to *run*, so runtime execution of the pipelines isn't possible in a Cloud Agent VM. The meaningful end-to-end deliverable — compiling the full plugin (including all CUDA modules) into a valid `stelline.cep` bundle — is what this environment enables and what was validated.

## Validation

Ran the exact recipe inside the base image on the VM:

- Meson configuration reported all loaders enabled: `CUDA: YES`, `Jetstream: YES 1.8.2`, `FBH5: YES`, `UVH5: YES`, `DAQIRI: YES`, `CEP bundle: YES`.
- `meson compile` completed all 683 build steps and produced `build/stelline.cep` (3.26 MB).
- The bundle is well-formed: contains `manifest.yml` (name `stelline`, version `0.5.0`, min Jetstream `1.8.2`), the compiled `targets/linux-x86_64-cuda/stelline.so`, and the three example flowgraphs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-765ea723-1593-4433-88cc-a22369524249?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-765ea723-1593-4433-88cc-a22369524249&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

