### PR TITLE
chore(release): Stelline 0.5.1 / CyberEther v1.9.0

### DIFF
--- a/.github/workflows/cep.yml
+++ b/.github/workflows/cep.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           - tag: x86_64-cuda
             runner: ubuntu-latest
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-x86_64-cuda
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-x86_64-cuda
             device: cuda
           - tag: aarch64-cuda
             runner: ubuntu-24.04-arm
-            base: ghcr.io/luigifcruz/cyberether:v1.8.2-ubuntu24-aarch64-cuda
+            base: ghcr.io/luigifcruz/cyberether:v1.9.0-ubuntu24-aarch64-cuda
             device: cuda
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,4 @@ jobs:
         uses: softprops/action-gh-release@v2.6.2
         with:
           files: .dist/artifacts/*.cep
+          generate_release_notes: true

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'stelline',
     ['cpp', 'cuda'],
-    version: '0.5.0',
+    version: '0.5.1',
     meson_version: '>=1.11.0',
     default_options: [
         'cpp_std=c++20',
@@ -22,7 +22,7 @@ if not plugin_is_linux
     error('Stelline only supports Linux targets for now.')
 endif
 
-minimum_jetstream_version = '1.8.2'
+minimum_jetstream_version = '1.9.0'
 
 #
 # Load Python

--- a/subprojects/cyberether.wrap
+++ b/subprojects/cyberether.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = cyberether
 url = https://github.com/luigifcruz/cyberether.git
-revision = v1.8.2
+revision = v1.9.0
 depth = 1
 clone-recursive = true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump Stelline plugin version to **0.5.1**
- Pin CyberEther to **v1.9.0** in the wrap, minimum Jetstream version, and CEP Docker base images
- Enable GitHub-generated release notes on tag publishes

## Release
**[v0.5.1](https://github.com/luigifcruz/stelline/releases/tag/v0.5.1)** is published (CEP artifact attached). Release workflow: https://github.com/luigifcruz/stelline/actions/runs/31630365655

GitHub auto-notes currently only include the compare link, because this PR had not been merged when the tag was pushed (auto-notes list merged PRs between tags). After merge, the release body can be edited to match the usual `What's Changed` format if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45a1d46f-8cce-4445-88ee-1a766640e0d7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45a1d46f-8cce-4445-88ee-1a766640e0d7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

